### PR TITLE
Use Emscripten::val to rewrite webnn delegate

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -21,7 +21,3 @@ tf_workspace1()
 load("@//tensorflow:workspace0.bzl", "tf_workspace0")
 
 tf_workspace0()
-
-load("//third_party/webnn:webnn.bzl", "webnn_configure")
-
-webnn_configure(name = "webnn_native_project")

--- a/tensorflow/lite/delegates/webnn/BUILD
+++ b/tensorflow/lite/delegates/webnn/BUILD
@@ -32,7 +32,6 @@ cc_library(
         "//tensorflow/lite/c:common",
         "//tensorflow/lite/schema:schema_fbs",
         "//tensorflow/lite/kernels/internal/utils:sparsity_format_converter",
-        "@webnn_native_project//:webnn-native",
         "@FP16",
     ],
 )
@@ -103,7 +102,6 @@ cc_library(
         "//tensorflow/lite/kernels/internal:compatibility",
         "//tensorflow/lite/kernels/internal:tensor",
         "//tensorflow/lite/tools/optimize:reduced_precision_support",
-        "@webnn_native_project//:webnn-native",
         "@FP16",
     ],
 )

--- a/tensorflow/lite/delegates/webnn/webnn_delegate.cc
+++ b/tensorflow/lite/delegates/webnn/webnn_delegate.cc
@@ -27,14 +27,10 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
-#include <webnn/webnn_cpp.h>
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
 #include <emscripten/html5.h>
-#include <emscripten/html5_webnn.h>
-#else
-#include <webnn/webnn_proc.h>
-#include <webnn_native/WebnnNative.h>
+#include <emscripten/val.h>
 #endif
 
 #include <fp16/fp16.h>
@@ -56,20 +52,17 @@ class Delegate {
 
  public:
   explicit Delegate(const TfLiteWebNNDelegateOptions* options) {
-    context_options_.devicePreference = static_cast<wnn::DevicePreference>(options->devicePreference);
-    context_options_.powerPreference = static_cast<wnn::PowerPreference>(options->powerPreference);
-    std::unordered_map<uint32_t, std::string> device_preference_names = {
-        {0, "Default"}, {1, "GPU"}, {2, "CPU"}};
-    std::unordered_map<uint32_t, std::string> power_preference_names = {
-        {0, "Default"}, {1, "High-performance"}, {2, "Low-power"}};
-#ifndef __EMSCRIPTEN__
-    instance_ = std::make_unique<webnn_native::Instance>();
-#endif
+    std::unordered_map<uint32_t, std::string> device_preference_name_s = {
+        {0, "default"}, {1, "gpu"}, {2, "cpu"}};
+    std::unordered_map<uint32_t, std::string> power_preference_name_s = {
+        {0, "default"}, {1, "high-performance"}, {2, "low-power"}};
+    device_preference_name_ = device_preference_name_s[options->devicePreference];
+    power_preference_name_ = power_preference_name_s[options->powerPreference];
     TFLITE_LOG_PROD_ONCE(tflite::TFLITE_LOG_INFO,
                          "Created TensorFlow Lite WebNN delegate for device"
                          " %s and power %s.",
-                         device_preference_names[options->devicePreference].c_str(),
-                         power_preference_names[options->powerPreference].c_str());
+                         device_preference_name_.c_str(),
+                         power_preference_name_.c_str());
   }
 
   TfLiteIntArray* PrepareOpsToDelegate(TfLiteContext* context);
@@ -98,11 +91,8 @@ class Delegate {
   std::unordered_set<int> static_unpack_nodes_;
   // Set of indices of tensors with unpacked static sparse weights.
   std::unordered_set<int> static_sparse_weights_;
-
-#ifndef __EMSCRIPTEN__
-  std::unique_ptr<webnn_native::Instance> instance_;
-#endif
-  wnn::ContextOptions context_options_;
+  std::string device_preference_name_;
+  std::string power_preference_name_;
 };
 
 class Subgraph {
@@ -130,20 +120,18 @@ class Subgraph {
     }
 
     // Create WebNN context and graph builder
-#ifdef __EMSCRIPTEN__
-    wnn::Context wnn_context = emscripten_webnn_create_context(&(delegate->context_options_));
-#else
-    WebnnProcTable backend_procs = webnn_native::GetProcs();
-    webnnProcSetProcs(&backend_procs);
-    wnn::Context wnn_context = delegate->instance_->CreateContext(&(delegate->context_options_));
+    thread_local const emscripten::val ml = emscripten::val::global("navigator")["ml"];
+    emscripten::val context_options = emscripten::val::object();
+    context_options.set("devicePreference", emscripten::val(delegate->device_preference_name_));
+    context_options.set("powerPreference", emscripten::val(delegate->power_preference_name_));
+    emscripten::val wnn_context = ml.call<emscripten::val>("createContext", context_options);
 
-#endif
-    if (!wnn_context) {
+    if (!wnn_context.as<bool>()) {
       TF_LITE_KERNEL_LOG(context, "Failed to create WebNN context.");
       return nullptr;
     }
-    wnn::GraphBuilder wnn_builder = wnn::CreateGraphBuilder(wnn_context);
-    if (!wnn_builder) {
+    emscripten::val wnn_builder = emscripten::val::global("MLGraphBuilder").new_(wnn_context);
+    if (!wnn_builder.as<bool>()) {
       TF_LITE_KERNEL_LOG(context, "Failed to create WebNN graph builder.");
       return nullptr;
     }
@@ -231,13 +219,13 @@ class Subgraph {
     }
 
     // WebNN operands for TFLite tensors
-    std::vector<wnn::Operand> webnn_operands(tensors.back() + 1);
+    std::unordered_map<int, emscripten::val> webnn_operands;
     std::unordered_set<int> compute_inputs;
     for (int t : tensors) {
-      wnn::OperandType datatype;
+      std::string datatype;
       switch (context->tensors[t].type) {
         case kTfLiteFloat32:
-          datatype = wnn::OperandType::Float32;
+          datatype = "float32";
           break;
         default:
           TF_LITE_KERNEL_LOG(
@@ -263,23 +251,23 @@ class Subgraph {
           &context->tensors[t].dims->data[context->tensors[t].dims->size]);
 
       if (inputs.count(t) != 0 || quasi_static_tensors.count(t) != 0) {
-        wnn::OperandDescriptor desc;
-        desc.dimensions = dims.data();
-        desc.dimensionsCount = dims.size();
-        desc.type = datatype;
+        emscripten::val desc = emscripten::val::object();
+        desc.set("type", emscripten::val(datatype));
+        desc.set("dimensions", emscripten::val::array(dims));
 
-        wnn::Operand operand;
+        emscripten::val operand = emscripten::val::object();
         if (data == nullptr) {
           compute_inputs.insert(t);
           std::string name = std::to_string(t);
-          operand = wnn_builder.Input(name.c_str(), &desc);
+          operand = wnn_builder.call<emscripten::val>("input", name, desc);
         } else {
-          wnn::ArrayBufferView buffer = {const_cast<void*>(data), context->tensors[t].bytes};
-          // buffer.buffer = data;
-          // buffer.byteLength = context->tensors[t].bytes;
-          operand = wnn_builder.Constant(&desc, &buffer);
+          auto data_size = context->tensors[t].bytes / 4;
+          emscripten::val view{ emscripten::typed_memory_view(data_size, static_cast<const float*>(data)) };
+          auto result = emscripten::val::global("Float32Array").new_(data_size);
+          result.call<void>("set", view);
+          operand = wnn_builder.call<emscripten::val>("constant", desc, result);
         }
-        webnn_operands[t] = operand;
+        webnn_operands.insert(std::make_pair(t, operand));
       }
     }
 
@@ -307,22 +295,21 @@ class Subgraph {
       }
     }
 
-    wnn::NamedOperands named_operands = wnn::CreateNamedOperands();
+    emscripten::val named_operands = emscripten::val::object();
     for (auto o : outputs) {
       std::string name = std::to_string(o);
-      if (!webnn_operands[o]) {
+      if (!webnn_operands.at(o).as<bool>()) {
         TF_LITE_KERNEL_LOG(context, "Invalid operand");
         return nullptr;
       }
-      named_operands.Set(name.c_str(), webnn_operands[o]);
+      named_operands.set(name, webnn_operands.at(o));
     }
 
-    wnn::Graph wnn_graph = wnn_builder.Build(named_operands);
-    if (!wnn_graph) {
+    emscripten::val wnn_graph = wnn_builder.call<emscripten::val>("build", named_operands);
+    if (!wnn_graph.as<bool>()) {
       TF_LITE_KERNEL_LOG(context, "failed to build WebNN graph");
       return nullptr;
     }
-
     return new Subgraph(wnn_graph, std::move(compute_inputs), std::move(outputs));
   }
 
@@ -350,37 +337,49 @@ class Subgraph {
     }
 
     if (any_pointers_changed) {
-      graph_inputs_ = wnn::CreateNamedInputs();
+      graph_inputs_ = emscripten::val::object();
       for (int t : inputs_) {
-        wnn_inputs_[t].resource.arrayBufferView.buffer = context->tensors[t].data.raw;
-        wnn_inputs_[t].resource.arrayBufferView.byteLength = context->tensors[t].bytes;
         std::string name = std::to_string(t);
-        graph_inputs_.Set(name.c_str(), &wnn_inputs_[t]);
+        auto input_size = context->tensors[t].bytes / 4;
+        auto input_data = context->tensors[t].data.f;
+        emscripten::val view{ emscripten::typed_memory_view(input_size, input_data) };
+        auto input = emscripten::val::global("Float32Array").new_(input_size);
+        input.call<void>("set", view);
+        graph_inputs_.set(name, input);
       }
 
-      graph_outputs_ = wnn::CreateNamedOutputs();
+      graph_outputs_ = emscripten::val::object();
       for (int t : outputs_) {
-        wnn_outputs_[t].arrayBufferView.buffer = context->tensors[t].data.raw;
-        wnn_outputs_[t].arrayBufferView.byteLength = context->tensors[t].bytes;
         std::string name = std::to_string(t);
-        graph_outputs_.Set(name.c_str(), &wnn_outputs_[t]);
+        auto output_size = context->tensors[t].bytes / 4;
+        auto output_data = context->tensors[t].data.f;
+        emscripten::val view{emscripten::typed_memory_view(output_size, output_data)};
+        auto output = emscripten::val::global("Float32Array").new_(output_size);
+        output.call<void>("set", view);
+        graph_outputs_.set(name, output);
       }
     }
 
-    wnn_graph_.Compute(graph_inputs_, graph_outputs_);
+    wnn_graph_.call<void>("compute", graph_inputs_, graph_outputs_);
+    // Copy output data from JS to TFLite output tensors' buffer.
+    for (int t : outputs_) {
+      auto output_tmp = emscripten::convertJSArrayToNumberVector<float>(graph_outputs_[std::to_string(t)]);
+      std::memcpy(context->tensors[t].data.f, output_tmp.data(), output_tmp.size()*sizeof(float));
+    }
+
     return kTfLiteOk;
   }
 
   static TfLiteStatus CalculatePadding(TfLiteContext* context,
-                                       TfLitePadding padding, wnn::AutoPad& auto_pad,
+                                       TfLitePadding padding, std::string& auto_pad,
                                        int node_index) {
     switch (padding) {
       case kTfLitePaddingSame: {
-        auto_pad = wnn::AutoPad::SameUpper;
+        auto_pad = "same-upper";
         return kTfLiteOk;
       }
       case kTfLitePaddingValid:
-        auto_pad = wnn::AutoPad::Explicit;
+        auto_pad = "explicit";
         return kTfLiteOk;
       default:
         TF_LITE_MAYBE_KERNEL_LOG(context,
@@ -465,42 +464,42 @@ class Subgraph {
     return kTfLiteOk;
   }
 
-  static TfLiteStatus CheckMediaPipeTransposedConvolutionParams(
-      TfLiteContext* context, const TfLiteTransposeConvParams* params,
-      int node_index) {
-    if (params->stride_width <= 0) {
-      TF_LITE_MAYBE_KERNEL_LOG(context, "invalid stride width %d in node #%d",
-                               params->stride_width, node_index);
-      return kTfLiteError;
-    }
-    if (params->stride_height <= 0) {
-      TF_LITE_MAYBE_KERNEL_LOG(context, "invalid stride height %d in node #%d",
-                               params->stride_height, node_index);
-      return kTfLiteError;
-    }
+  // static TfLiteStatus CheckMediaPipeTransposedConvolutionParams(
+  //     TfLiteContext* context, const TfLiteTransposeConvParams* params,
+  //     int node_index) {
+  //   if (params->stride_width <= 0) {
+  //     TF_LITE_MAYBE_KERNEL_LOG(context, "invalid stride width %d in node #%d",
+  //                              params->stride_width, node_index);
+  //     return kTfLiteError;
+  //   }
+  //   if (params->stride_height <= 0) {
+  //     TF_LITE_MAYBE_KERNEL_LOG(context, "invalid stride height %d in node #%d",
+  //                              params->stride_height, node_index);
+  //     return kTfLiteError;
+  //   }
 
-    return kTfLiteOk;
-  }
+  //   return kTfLiteOk;
+  // }
 
-  static TfLiteStatus CheckFullyConnectedParams(
-      TfLiteContext* context, const TfLiteFullyConnectedParams* params,
-      int node_index) {
-    if (params->weights_format != kTfLiteFullyConnectedWeightsFormatDefault) {
-      TF_LITE_MAYBE_KERNEL_LOG(
-          context, "unsupported non-default weights format in node #%d",
-          node_index);
-      return kTfLiteError;
-    }
+  // static TfLiteStatus CheckFullyConnectedParams(
+  //     TfLiteContext* context, const TfLiteFullyConnectedParams* params,
+  //     int node_index) {
+  //   if (params->weights_format != kTfLiteFullyConnectedWeightsFormatDefault) {
+  //     TF_LITE_MAYBE_KERNEL_LOG(
+  //         context, "unsupported non-default weights format in node #%d",
+  //         node_index);
+  //     return kTfLiteError;
+  //   }
 
-    if (params->asymmetric_quantize_inputs) {
-      TF_LITE_MAYBE_KERNEL_LOG(
-          context, "unsupported asymmetric quantize inputs in node #%d",
-          node_index);
-      return kTfLiteError;
-    }
+  //   if (params->asymmetric_quantize_inputs) {
+  //     TF_LITE_MAYBE_KERNEL_LOG(
+  //         context, "unsupported asymmetric quantize inputs in node #%d",
+  //         node_index);
+  //     return kTfLiteError;
+  //   }
 
-    return kTfLiteOk;
-  }
+  //   return kTfLiteOk;
+  // }
 
   static TfLiteStatus CheckPoolingParams(TfLiteContext* context,
                                          const TfLitePoolParams* params,
@@ -764,29 +763,29 @@ class Subgraph {
     return kTfLiteOk;
   }
 
-  static wnn::Operand BuildClamp(
-      const wnn::GraphBuilder& builder, const wnn::Operand& input,
+  static emscripten::val BuildClamp(
+      const emscripten::val& builder, const emscripten::val& input,
       float min_value, float max_value, std::vector<std::unique_ptr<char>>& constant_buffers) {
-    wnn::ClampOptions options;
-    options.minValue = min_value;
-    options.maxValue = max_value;
-    return builder.Clamp(input, &options);
+    emscripten::val options = emscripten::val::object();
+    options.set("minValue", emscripten::val(min_value));
+    options.set("maxValue", emscripten::val(max_value));
+    return builder.call<emscripten::val>("clamp", input, options);
   }
 
-  static wnn::FusionOperator GetClampOperator(
-      const wnn::GraphBuilder& builder, float min_value, float max_value) {
-    wnn::ClampOptions options;
-    options.minValue = min_value;
-    options.maxValue = max_value;
-    return builder.ClampOperator(&options);
+  static emscripten::val GetClampOperator(
+      const emscripten::val& builder, float min_value, float max_value) {
+    emscripten::val options = emscripten::val::object();
+    options.set("minValue", emscripten::val(min_value));
+    options.set("maxValue", emscripten::val(max_value));
+    return builder.call<emscripten::val>("clamp", options);
   }
 
   static TfLiteStatus GetActivation(
-      const wnn::GraphBuilder& builder, TfLiteContext* context, int node_index,
-      TfLiteFusedActivation activation, wnn::FusionOperator& activation_operator) {
+      const emscripten::val& builder, TfLiteContext* context, int node_index,
+      TfLiteFusedActivation activation, emscripten::val& activation_operator) {
     switch (activation) {
       case kTfLiteActRelu:
-        activation_operator = builder.ReluOperator();
+        activation_operator = builder.call<emscripten::val>("relu");
         return kTfLiteOk;
       case kTfLiteActReluN1To1:
         activation_operator = GetClampOperator(builder, -1.0f, +1.0f);
@@ -795,7 +794,7 @@ class Subgraph {
         activation_operator = GetClampOperator(builder, 0.0f, 6.0f);
         return kTfLiteOk;
       case kTfLiteActTanh:
-        activation_operator = builder.TanhOperator();
+        activation_operator = builder.call<emscripten::val>("tanh");
         return kTfLiteOk;
       case kTfLiteActSignBit:
         TF_LITE_MAYBE_KERNEL_LOG(
@@ -803,7 +802,7 @@ class Subgraph {
             node_index);
         return kTfLiteError;
       case kTfLiteActSigmoid:
-          activation_operator = builder.SigmoidOperator();
+          activation_operator = builder.call<emscripten::val>("sigmoid");
       default:
         TF_LITE_MAYBE_KERNEL_LOG(context,
                                  "invalid fused activation (%d) in node #%d",
@@ -813,32 +812,32 @@ class Subgraph {
   }
 
   static TfLiteStatus VisitActivation(
-      const wnn::GraphBuilder& builder, TfLiteContext* context, int node_index,
+      const emscripten::val& builder, TfLiteContext* context, int node_index,
       int input_tensor_id, int output_tensor_id, TfLiteFusedActivation activation,
-      std::vector<wnn::Operand>& webnn_operands, std::vector<std::unique_ptr<char>>& constant_buffers) {
+      std::unordered_map<int, emscripten::val>& webnn_operands, std::vector<std::unique_ptr<char>>& constant_buffers) {
     switch (activation) {
       case kTfLiteActNone:
         return kTfLiteOk;
       case kTfLiteActRelu:
-        if (builder) {
-          webnn_operands[output_tensor_id] = builder.Relu(webnn_operands[input_tensor_id]);
+        if (!builder.isNull()) {
+          webnn_operands.at(output_tensor_id) = builder.call<emscripten::val>("relu", webnn_operands.at(input_tensor_id));
         }
         return kTfLiteOk;
       case kTfLiteActReluN1To1:
-        if (builder) {
-          webnn_operands[output_tensor_id] = BuildClamp(
-              builder, webnn_operands[input_tensor_id], -1.0f, +1.0f, constant_buffers);
+        if (!builder.isNull()) {
+          webnn_operands.at(output_tensor_id) = BuildClamp(
+              builder, webnn_operands.at(input_tensor_id), -1.0f, +1.0f, constant_buffers);
         }
         return kTfLiteOk;
       case kTfLiteActRelu6:
-        if (builder) {
-          webnn_operands[output_tensor_id] = BuildClamp(
-              builder, webnn_operands[input_tensor_id], 0.0f, 6.0f, constant_buffers);
+        if (!builder.isNull()) {
+          webnn_operands.at(output_tensor_id) = BuildClamp(
+              builder, webnn_operands.at(input_tensor_id), 0.0f, 6.0f, constant_buffers);
         }
         return kTfLiteOk;
       case kTfLiteActTanh:
-        if (builder) {
-          webnn_operands[output_tensor_id] = builder.Tanh(webnn_operands[input_tensor_id]);
+        if (!builder.isNull()) {
+          webnn_operands.at(output_tensor_id) = builder.call<emscripten::val>("tanh", webnn_operands.at(input_tensor_id));
         }
         return kTfLiteOk;
       case kTfLiteActSignBit:
@@ -847,8 +846,8 @@ class Subgraph {
             node_index);
         return kTfLiteError;
       case kTfLiteActSigmoid:
-        if (builder) {
-          webnn_operands[output_tensor_id] = builder.Sigmoid(webnn_operands[input_tensor_id]);
+        if (!builder.isNull()) {
+          webnn_operands.at(output_tensor_id) = builder.call<emscripten::val>("sigmoid", webnn_operands.at(input_tensor_id));
         }
         return kTfLiteOk;
       default:
@@ -860,17 +859,17 @@ class Subgraph {
   }
 
   static TfLiteStatus VisitNode(
-      const wnn::GraphBuilder& builder, TfLiteContext* context,
+      const emscripten::val& builder, TfLiteContext* context,
       TfLiteRegistration* registration, TfLiteNode* node, int node_index,
       const std::unordered_set<int>& quasi_static_tensors,
-      std::vector<wnn::Operand>& webnn_operands,
+      std::unordered_map<int, emscripten::val>& webnn_operands,
       std::vector<std::unique_ptr<char>>& constant_buffers) {
     // TFLite context used for logging purposes. When we create a new node
     // (subgraph is non-null), logging context is the same as context, and error
     // messages are passed to TFLite. When we detect supported operations
     // (subgraph is null), logging context is null, and error messages are
     // supressed.
-    TfLiteContext* logging_context = builder == nullptr ? nullptr : context;
+    TfLiteContext* logging_context = builder.isNull() ? nullptr : context;
     switch (registration->builtin_code) {
       case kTfLiteBuiltinAdd: {
         const TfLiteAddParams* add_params =
@@ -879,16 +878,16 @@ class Subgraph {
         return VisitAddNode(builder, logging_context, node_index, node,
                             context->tensors, add_params, webnn_operands, constant_buffers);
       }
-      case kTfLiteBuiltinMul: {
-        const TfLiteMulParams* mul_params =
-            static_cast<const TfLiteMulParams*>(node->builtin_data);
+      // case kTfLiteBuiltinMul: {
+      //   const TfLiteMulParams* mul_params =
+      //       static_cast<const TfLiteMulParams*>(node->builtin_data);
 
-        return VisitMulNode(builder, logging_context, node_index, node,
-                            context->tensors, mul_params, webnn_operands, constant_buffers);
-      }
-      case kTfLiteBuiltinPad:
-        return VisitPadNode(builder, logging_context, node_index, node,
-                            context->tensors, webnn_operands, constant_buffers);
+      //   return VisitMulNode(builder, logging_context, node_index, node,
+      //                       context->tensors, mul_params, webnn_operands, constant_buffers);
+      // }
+      // case kTfLiteBuiltinPad:
+      //   return VisitPadNode(builder, logging_context, node_index, node,
+      //                       context->tensors, webnn_operands, constant_buffers);
       case kTfLiteBuiltinAveragePool2d: {
         const TfLitePoolParams* pool_params =
             static_cast<const TfLitePoolParams*>(node->builtin_data);
@@ -897,30 +896,30 @@ class Subgraph {
                                       node, context->tensors, pool_params,
                                       webnn_operands, constant_buffers);
       }
-      case kTfLiteBuiltinMaxPool2d: {
-        const TfLitePoolParams* pool_params =
-            static_cast<const TfLitePoolParams*>(node->builtin_data);
+      // case kTfLiteBuiltinMaxPool2d: {
+      //   const TfLitePoolParams* pool_params =
+      //       static_cast<const TfLitePoolParams*>(node->builtin_data);
 
-        return VisitMaxPool2DNode(builder, logging_context, node_index,
-                                  node, context->tensors, pool_params,
-                                  webnn_operands, constant_buffers);
-      }
-      case kTfLiteBuiltinMean: {
-        const TfLiteReducerParams* reducer_params =
-            static_cast<const TfLiteReducerParams*>(node->builtin_data);
+      //   return VisitMaxPool2DNode(builder, logging_context, node_index,
+      //                             node, context->tensors, pool_params,
+      //                             webnn_operands, constant_buffers);
+      // }
+      // case kTfLiteBuiltinMean: {
+      //   const TfLiteReducerParams* reducer_params =
+      //       static_cast<const TfLiteReducerParams*>(node->builtin_data);
 
-        return VisitMeanNode(builder, logging_context, node_index,
-                             node, context->tensors, reducer_params,
-                             webnn_operands, constant_buffers);
-      }
-      case kTfLiteBuiltinConcatenation: {
-        const TfLiteConcatenationParams* concat_params =
-            static_cast<const TfLiteConcatenationParams*>(node->builtin_data);
+      //   return VisitMeanNode(builder, logging_context, node_index,
+      //                        node, context->tensors, reducer_params,
+      //                        webnn_operands, constant_buffers);
+      // }
+      // case kTfLiteBuiltinConcatenation: {
+      //   const TfLiteConcatenationParams* concat_params =
+      //       static_cast<const TfLiteConcatenationParams*>(node->builtin_data);
 
-        return VisitConcatenationNode(builder, logging_context, node_index, node,
-                                      context->tensors, concat_params,
-                                      webnn_operands, constant_buffers);
-      }
+      //   return VisitConcatenationNode(builder, logging_context, node_index, node,
+      //                                 context->tensors, concat_params,
+      //                                 webnn_operands, constant_buffers);
+      // }
       case kTfLiteBuiltinConv2d: {
         const TfLiteConvParams* conv_params =
             static_cast<const TfLiteConvParams*>(node->builtin_data);
@@ -937,23 +936,23 @@ class Subgraph {
                                         node, context->tensors, dwconv_params,
                                         quasi_static_tensors, webnn_operands, constant_buffers);
       }
-      case kTfLiteBuiltinFullyConnected: {
-        const TfLiteFullyConnectedParams* fc_params =
-            static_cast<const TfLiteFullyConnectedParams*>(node->builtin_data);
+      // case kTfLiteBuiltinFullyConnected: {
+      //   const TfLiteFullyConnectedParams* fc_params =
+      //       static_cast<const TfLiteFullyConnectedParams*>(node->builtin_data);
 
-        return VisitFullyConnectedNode(builder, logging_context, node_index, node,
-                                       context->tensors, fc_params, quasi_static_tensors,
-                                       webnn_operands, constant_buffers);
-      }
-      case kTfLiteBuiltinHardSwish:
-        return VisitHardSwishNode(builder, logging_context, node_index, node,
-                                  context->tensors, webnn_operands);
-      case kTfLiteBuiltinLogistic:
-        return VisitLogisticNode(builder, logging_context, node_index, node,
-                                 context->tensors, webnn_operands);
-      case kTfLiteBuiltinRelu:
-        return VisitReluNode(builder, logging_context, node_index, node,
-                             context->tensors, webnn_operands);
+      //   return VisitFullyConnectedNode(builder, logging_context, node_index, node,
+      //                                  context->tensors, fc_params, quasi_static_tensors,
+      //                                  webnn_operands, constant_buffers);
+      // }
+      // case kTfLiteBuiltinHardSwish:
+      //   return VisitHardSwishNode(builder, logging_context, node_index, node,
+      //                             context->tensors, webnn_operands);
+      // case kTfLiteBuiltinLogistic:
+      //   return VisitLogisticNode(builder, logging_context, node_index, node,
+      //                            context->tensors, webnn_operands);
+      // case kTfLiteBuiltinRelu:
+      //   return VisitReluNode(builder, logging_context, node_index, node,
+      //                        context->tensors, webnn_operands);
       case kTfLiteBuiltinReshape: {
         const TfLiteReshapeParams* reshape_params =
             static_cast<const TfLiteReshapeParams*>(node->builtin_data);
@@ -961,14 +960,14 @@ class Subgraph {
         return VisitReshapeNode(builder, logging_context, node_index, node,
                                 context->tensors, reshape_params, webnn_operands);
       }
-      case kTfLiteBuiltinResizeBilinear: {
-        const TfLiteResizeBilinearParams* resize_params =
-            static_cast<const TfLiteResizeBilinearParams*>(node->builtin_data);
+      // case kTfLiteBuiltinResizeBilinear: {
+      //   const TfLiteResizeBilinearParams* resize_params =
+      //       static_cast<const TfLiteResizeBilinearParams*>(node->builtin_data);
 
-        return VisitResizeBilinearNode(builder, logging_context, node_index,
-                                       node, context->tensors, resize_params,
-                                       webnn_operands);
-      }
+      //   return VisitResizeBilinearNode(builder, logging_context, node_index,
+      //                                  node, context->tensors, resize_params,
+      //                                  webnn_operands);
+      // }
       case kTfLiteBuiltinSoftmax: {
         const TfLiteSoftmaxParams* softmax_params =
             static_cast<const TfLiteSoftmaxParams*>(node->builtin_data);
@@ -976,46 +975,46 @@ class Subgraph {
         return VisitSoftmaxNode(builder, logging_context, node_index, node,
                                 context->tensors, softmax_params, webnn_operands);
       }
-      case kTfLiteBuiltinSplit: {
-        const TfLiteSplitParams* split_params =
-            static_cast<const TfLiteSplitParams*>(node->builtin_data);
+      // case kTfLiteBuiltinSplit: {
+      //   const TfLiteSplitParams* split_params =
+      //       static_cast<const TfLiteSplitParams*>(node->builtin_data);
 
-        return VisitSplitNode(builder, logging_context, node_index, node,
-                                context->tensors, split_params, webnn_operands);
-      }
-      case kTfLiteBuiltinTanh:
-        return VisitTanhNode(builder, logging_context, node_index, node,
-                             context->tensors, webnn_operands);
-      case kTfLiteBuiltinUnpack: {
-        const TfLiteUnpackParams* unpack_params =
-            static_cast<const TfLiteUnpackParams*>(node->builtin_data);
+      //   return VisitSplitNode(builder, logging_context, node_index, node,
+      //                           context->tensors, split_params, webnn_operands);
+      // }
+      // case kTfLiteBuiltinTanh:
+      //   return VisitTanhNode(builder, logging_context, node_index, node,
+      //                        context->tensors, webnn_operands);
+      // case kTfLiteBuiltinUnpack: {
+      //   const TfLiteUnpackParams* unpack_params =
+      //       static_cast<const TfLiteUnpackParams*>(node->builtin_data);
 
-        return VisitUnpackNode(builder, logging_context, node_index, node,
-                               context->tensors, unpack_params, webnn_operands);
-      }
-      case kTfLiteBuiltinCustom: {
-        if (strcmp(registration->custom_name, "Convolution2DTransposeBias") ==
-            0) {
-          TfLiteTransposeConvParams deconv_params = {kTfLitePaddingUnknown};
-          std::memcpy(&deconv_params, node->custom_initial_data,
-                      node->custom_initial_data_size);
+      //   return VisitUnpackNode(builder, logging_context, node_index, node,
+      //                          context->tensors, unpack_params, webnn_operands);
+      // }
+      // case kTfLiteBuiltinCustom: {
+      //   if (strcmp(registration->custom_name, "Convolution2DTransposeBias") ==
+      //       0) {
+      //     TfLiteTransposeConvParams deconv_params = {kTfLitePaddingUnknown};
+      //     std::memcpy(&deconv_params, node->custom_initial_data,
+      //                 node->custom_initial_data_size);
 
-          return VisitMediaPipeDeconvolutionNode(
-              builder, context, node_index, node, context->tensors,
-              &deconv_params, quasi_static_tensors, webnn_operands);
-        }
-        return kTfLiteError;
-      }
+      //     return VisitMediaPipeDeconvolutionNode(
+      //         builder, context, node_index, node, context->tensors,
+      //         &deconv_params, quasi_static_tensors, webnn_operands);
+      //   }
+      //   return kTfLiteError;
+      // }
       default:
         return kTfLiteError;
     }
   }
 
   static TfLiteStatus VisitAddNode(
-      const wnn::GraphBuilder& builder, TfLiteContext* logging_context, int node_index,
+      const emscripten::val& builder, TfLiteContext* logging_context, int node_index,
       TfLiteNode* node, const TfLiteTensor* tensors,
       const TfLiteAddParams* add_params,
-      std::vector<wnn::Operand>& webnn_operands,
+      std::unordered_map<int, emscripten::val>& webnn_operands,
       std::vector<std::unique_ptr<char>>& constant_buffers) {
     TF_LITE_ENSURE_STATUS(
         CheckNumInputsAndOutputs(logging_context, node, 2, 1, node_index));
@@ -1040,13 +1039,12 @@ class Subgraph {
         logging_context, output_tensor, output_tensor_id, node_index));
     TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
         logging_context, output_tensor, output_tensor_id, node_index));
-
-    if (builder) {
-      TF_LITE_ENSURE(logging_context, webnn_operands[input1_tensor_id]);
-      TF_LITE_ENSURE(logging_context, webnn_operands[input2_tensor_id]);
-      webnn_operands[output_tensor_id] =
-          builder.Add(webnn_operands[input1_tensor_id], webnn_operands[input2_tensor_id]);
-      TF_LITE_ENSURE(logging_context, webnn_operands[output_tensor_id]);
+    if (!builder.isNull()) {
+      TF_LITE_ENSURE(logging_context, webnn_operands.at(input1_tensor_id).as<bool>());
+      TF_LITE_ENSURE(logging_context, webnn_operands.at(input2_tensor_id).as<bool>());
+      webnn_operands.insert(std::make_pair(output_tensor_id,
+          builder.call<emscripten::val>("add", webnn_operands.at(input1_tensor_id), webnn_operands.at(input2_tensor_id))));
+      TF_LITE_ENSURE(logging_context, webnn_operands.at(output_tensor_id).as<bool>());
     }
 
     if (add_params != nullptr) {
@@ -1058,139 +1056,139 @@ class Subgraph {
     return kTfLiteOk;
   }
 
-  static TfLiteStatus VisitMulNode(
-      const wnn::GraphBuilder& builder, TfLiteContext* logging_context, int node_index,
-      TfLiteNode* node, const TfLiteTensor* tensors,
-      const TfLiteMulParams* mul_params,
-      std::vector<wnn::Operand>& webnn_operands,
-      std::vector<std::unique_ptr<char>>& constant_buffers) {
-    TF_LITE_ENSURE_STATUS(
-        CheckNumInputsAndOutputs(logging_context, node, 2, 1, node_index));
+  // static TfLiteStatus VisitMulNode(
+  //     const wnn::GraphBuilder& builder, TfLiteContext* logging_context, int node_index,
+  //     TfLiteNode* node, const TfLiteTensor* tensors,
+  //     const TfLiteMulParams* mul_params,
+  //     std::vector<wnn::Operand>& webnn_operands,
+  //     std::vector<std::unique_ptr<char>>& constant_buffers) {
+  //   TF_LITE_ENSURE_STATUS(
+  //       CheckNumInputsAndOutputs(logging_context, node, 2, 1, node_index));
 
-    const int input1_tensor_id = node->inputs->data[0];
-    const TfLiteTensor& input1_tensor = tensors[input1_tensor_id];
-    TF_LITE_ENSURE_STATUS(CheckTensorFloat32OrQInt8Type(
-        logging_context, input1_tensor, input1_tensor_id, node_index));
-    TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
-        logging_context, input1_tensor, input1_tensor_id, node_index));
+  //   const int input1_tensor_id = node->inputs->data[0];
+  //   const TfLiteTensor& input1_tensor = tensors[input1_tensor_id];
+  //   TF_LITE_ENSURE_STATUS(CheckTensorFloat32OrQInt8Type(
+  //       logging_context, input1_tensor, input1_tensor_id, node_index));
+  //   TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
+  //       logging_context, input1_tensor, input1_tensor_id, node_index));
 
-    const int input2_tensor_id = node->inputs->data[1];
-    const TfLiteTensor& input2_tensor = tensors[input2_tensor_id];
-    TF_LITE_ENSURE_STATUS(CheckTensorFloat32OrQInt8Type(
-        logging_context, input2_tensor, input2_tensor_id, node_index));
-    TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
-        logging_context, input2_tensor, input2_tensor_id, node_index));
+  //   const int input2_tensor_id = node->inputs->data[1];
+  //   const TfLiteTensor& input2_tensor = tensors[input2_tensor_id];
+  //   TF_LITE_ENSURE_STATUS(CheckTensorFloat32OrQInt8Type(
+  //       logging_context, input2_tensor, input2_tensor_id, node_index));
+  //   TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
+  //       logging_context, input2_tensor, input2_tensor_id, node_index));
 
-    const int output_tensor_id = node->outputs->data[0];
-    const TfLiteTensor& output_tensor = tensors[output_tensor_id];
-    TF_LITE_ENSURE_STATUS(CheckTensorFloat32OrQInt8Type(
-        logging_context, output_tensor, output_tensor_id, node_index));
-    TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
-        logging_context, output_tensor, output_tensor_id, node_index));
+  //   const int output_tensor_id = node->outputs->data[0];
+  //   const TfLiteTensor& output_tensor = tensors[output_tensor_id];
+  //   TF_LITE_ENSURE_STATUS(CheckTensorFloat32OrQInt8Type(
+  //       logging_context, output_tensor, output_tensor_id, node_index));
+  //   TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
+  //       logging_context, output_tensor, output_tensor_id, node_index));
 
-    if (builder) {
-      TF_LITE_ENSURE(logging_context, webnn_operands[input1_tensor_id]);
-      TF_LITE_ENSURE(logging_context, webnn_operands[input2_tensor_id]);
-      webnn_operands[output_tensor_id] =
-          builder.Mul(webnn_operands[input1_tensor_id], webnn_operands[input2_tensor_id]);
-      TF_LITE_ENSURE(logging_context, webnn_operands[output_tensor_id]);
-    }
+  //   if (builder) {
+  //     TF_LITE_ENSURE(logging_context, webnn_operands[input1_tensor_id]);
+  //     TF_LITE_ENSURE(logging_context, webnn_operands[input2_tensor_id]);
+  //     webnn_operands[output_tensor_id] =
+  //         builder.Mul(webnn_operands[input1_tensor_id], webnn_operands[input2_tensor_id]);
+  //     TF_LITE_ENSURE(logging_context, webnn_operands[output_tensor_id]);
+  //   }
 
-    if (mul_params != nullptr) {
-      TF_LITE_ENSURE_STATUS(VisitActivation(
-          builder, logging_context, node_index, output_tensor_id, output_tensor_id,
-          mul_params->activation, webnn_operands, constant_buffers));
-    }
+  //   if (mul_params != nullptr) {
+  //     TF_LITE_ENSURE_STATUS(VisitActivation(
+  //         builder, logging_context, node_index, output_tensor_id, output_tensor_id,
+  //         mul_params->activation, webnn_operands, constant_buffers));
+  //   }
 
-    return kTfLiteOk;
-  }
+  //   return kTfLiteOk;
+  // }
 
-  static TfLiteStatus VisitPadNode(
-      const wnn::GraphBuilder& builder, TfLiteContext* logging_context, int node_index,
-      TfLiteNode* node, const TfLiteTensor* tensors,
-      std::vector<wnn::Operand>& webnn_operands,
-      std::vector<std::unique_ptr<char>>& constant_buffers) {
-    TF_LITE_ENSURE_STATUS(
-        CheckNumInputsAndOutputs(logging_context, node, 2, 1, node_index));
+  // static TfLiteStatus VisitPadNode(
+  //     const wnn::GraphBuilder& builder, TfLiteContext* logging_context, int node_index,
+  //     TfLiteNode* node, const TfLiteTensor* tensors,
+  //     std::vector<wnn::Operand>& webnn_operands,
+  //     std::vector<std::unique_ptr<char>>& constant_buffers) {
+  //   TF_LITE_ENSURE_STATUS(
+  //       CheckNumInputsAndOutputs(logging_context, node, 2, 1, node_index));
 
-    const int input_tensor_id = node->inputs->data[0];
-    const TfLiteTensor& input_tensor = tensors[input_tensor_id];
-    TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
-        logging_context, input_tensor, input_tensor_id, node_index));
-    TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
-        logging_context, input_tensor, input_tensor_id, node_index));
+  //   const int input_tensor_id = node->inputs->data[0];
+  //   const TfLiteTensor& input_tensor = tensors[input_tensor_id];
+  //   TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
+  //       logging_context, input_tensor, input_tensor_id, node_index));
+  //   TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
+  //       logging_context, input_tensor, input_tensor_id, node_index));
 
-    const int padding_tensor_id = node->inputs->data[1];
-    const TfLiteTensor& paddings_tensor = tensors[padding_tensor_id];
-    TF_LITE_ENSURE_STATUS(CheckTensorType(logging_context, paddings_tensor,
-                                          kTfLiteInt32, padding_tensor_id,
-                                          node_index));
-    TF_LITE_ENSURE_STATUS(CheckPaddingsTensorShape(
-        logging_context, paddings_tensor, input_tensor.dims->size,
-        padding_tensor_id, node_index));
-    TF_LITE_ENSURE_STATUS(CheckTensorStaticAllocation(
-        logging_context, paddings_tensor, padding_tensor_id, node_index));
+  //   const int padding_tensor_id = node->inputs->data[1];
+  //   const TfLiteTensor& paddings_tensor = tensors[padding_tensor_id];
+  //   TF_LITE_ENSURE_STATUS(CheckTensorType(logging_context, paddings_tensor,
+  //                                         kTfLiteInt32, padding_tensor_id,
+  //                                         node_index));
+  //   TF_LITE_ENSURE_STATUS(CheckPaddingsTensorShape(
+  //       logging_context, paddings_tensor, input_tensor.dims->size,
+  //       padding_tensor_id, node_index));
+  //   TF_LITE_ENSURE_STATUS(CheckTensorStaticAllocation(
+  //       logging_context, paddings_tensor, padding_tensor_id, node_index));
 
-    const int output_tensor_id = node->outputs->data[0];
-    const TfLiteTensor& output_tensor = tensors[output_tensor_id];
-    TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
-        logging_context, output_tensor, output_tensor_id, node_index));
-    TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
-        logging_context, output_tensor, output_tensor_id, node_index));
+  //   const int output_tensor_id = node->outputs->data[0];
+  //   const TfLiteTensor& output_tensor = tensors[output_tensor_id];
+  //   TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
+  //       logging_context, output_tensor, output_tensor_id, node_index));
+  //   TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
+  //       logging_context, output_tensor, output_tensor_id, node_index));
 
-    const int32_t* paddings_data =
-        reinterpret_cast<const int32_t*>(paddings_tensor.data.data);
-    for (int i = 0; i < paddings_tensor.dims->data[0]; i++) {
-      const int32_t pre_padding = paddings_data[i * 2 + 0];
-      if (pre_padding < 0) {
-        TF_LITE_MAYBE_KERNEL_LOG(
-            logging_context,
-            "invalid pre-padding %d for dimension #%d in node %d", pre_padding,
-            i, node_index);
-        return kTfLiteError;
-      }
+  //   const int32_t* paddings_data =
+  //       reinterpret_cast<const int32_t*>(paddings_tensor.data.data);
+  //   for (int i = 0; i < paddings_tensor.dims->data[0]; i++) {
+  //     const int32_t pre_padding = paddings_data[i * 2 + 0];
+  //     if (pre_padding < 0) {
+  //       TF_LITE_MAYBE_KERNEL_LOG(
+  //           logging_context,
+  //           "invalid pre-padding %d for dimension #%d in node %d", pre_padding,
+  //           i, node_index);
+  //       return kTfLiteError;
+  //     }
 
-      const int32_t post_padding = paddings_data[i * 2 + 1];
-      if (post_padding < 0) {
-        TF_LITE_MAYBE_KERNEL_LOG(
-            logging_context,
-            "invalid post-padding %d for dimension #%d in node %d", pre_padding,
-            i, node_index);
-        return kTfLiteError;
-      }
-    }
+  //     const int32_t post_padding = paddings_data[i * 2 + 1];
+  //     if (post_padding < 0) {
+  //       TF_LITE_MAYBE_KERNEL_LOG(
+  //           logging_context,
+  //           "invalid post-padding %d for dimension #%d in node %d", pre_padding,
+  //           i, node_index);
+  //       return kTfLiteError;
+  //     }
+  //   }
 
-    if (builder) {
-      size_t rank = paddings_tensor.dims->data[0];
-      std::vector<int32_t> padding(rank * 2);
-      for (int i = 0; i < rank; i++) {
-        padding[i * 2 + 0] = static_cast<int32_t>(paddings_data[i * 2 + 0]);
-        padding[i * 2 + 1] = static_cast<int32_t>(paddings_data[i * 2 + 1]);
-      }
-      const size_t padding_buffer_length = sizeof(int32_t) * padding.size();
-      std::unique_ptr<char> padding_buffer(new char[padding_buffer_length]);
-      std::memcpy(padding_buffer.get(), padding.data(), padding_buffer_length);
-      std::vector<int32_t> dims = {static_cast<int32_t>(rank), 2};
-      wnn::OperandDescriptor desc = {
-        wnn::OperandType::Int32, dims.data(), static_cast<uint32_t>(dims.size())};
-      wnn::ArrayBufferView padding_buffer_view = {padding_buffer.get(), padding_buffer_length};
-      wnn::Operand padding_operand = builder.Constant(&desc, &padding_buffer_view);
-      constant_buffers.push_back(std::move(padding_buffer));
+  //   if (builder) {
+  //     size_t rank = paddings_tensor.dims->data[0];
+  //     std::vector<int32_t> padding(rank * 2);
+  //     for (int i = 0; i < rank; i++) {
+  //       padding[i * 2 + 0] = static_cast<int32_t>(paddings_data[i * 2 + 0]);
+  //       padding[i * 2 + 1] = static_cast<int32_t>(paddings_data[i * 2 + 1]);
+  //     }
+  //     const size_t padding_buffer_length = sizeof(int32_t) * padding.size();
+  //     std::unique_ptr<char> padding_buffer(new char[padding_buffer_length]);
+  //     std::memcpy(padding_buffer.get(), padding.data(), padding_buffer_length);
+  //     std::vector<int32_t> dims = {static_cast<int32_t>(rank), 2};
+  //     wnn::OperandDescriptor desc = {
+  //       wnn::OperandType::Int32, dims.data(), static_cast<uint32_t>(dims.size())};
+  //     wnn::ArrayBufferView padding_buffer_view = {padding_buffer.get(), padding_buffer_length};
+  //     wnn::Operand padding_operand = builder.Constant(&desc, &padding_buffer_view);
+  //     constant_buffers.push_back(std::move(padding_buffer));
 
-      TF_LITE_ENSURE(logging_context, webnn_operands[input_tensor_id]);
-      webnn_operands[output_tensor_id] =
-          builder.Pad(webnn_operands[input_tensor_id], padding_operand);
-      TF_LITE_ENSURE(logging_context, webnn_operands[output_tensor_id]);
-    }
+  //     TF_LITE_ENSURE(logging_context, webnn_operands[input_tensor_id]);
+  //     webnn_operands[output_tensor_id] =
+  //         builder.Pad(webnn_operands[input_tensor_id], padding_operand);
+  //     TF_LITE_ENSURE(logging_context, webnn_operands[output_tensor_id]);
+  //   }
 
-    return kTfLiteOk;
-  }
+  //   return kTfLiteOk;
+  // }
 
   static TfLiteStatus VisitAveragePool2DNode(
-      const wnn::GraphBuilder& builder, TfLiteContext* logging_context, int node_index,
+      const emscripten::val& builder, TfLiteContext* logging_context, int node_index,
       TfLiteNode* node, const TfLiteTensor* tensors,
       const TfLitePoolParams* pool_params,
-      std::vector<wnn::Operand>& webnn_operands,
+      std::unordered_map<int, emscripten::val>& webnn_operands,
       std::vector<std::unique_ptr<char>>& constant_buffers) {
     TF_LITE_ENSURE_STATUS(
         CheckNumInputsAndOutputs(logging_context, node, 1, 1, node_index));
@@ -1212,32 +1210,33 @@ class Subgraph {
     TF_LITE_ENSURE_STATUS(
         CheckPoolingParams(logging_context, pool_params, node_index));
 
-    wnn::AutoPad auto_pad;
+    std::string auto_pad;
     TF_LITE_ENSURE_STATUS(CalculatePadding(
         logging_context, pool_params->padding, auto_pad, node_index));
 
-    if (builder) {
-      wnn::Operand output;
-      TF_LITE_ENSURE(logging_context, webnn_operands[input_tensor_id]);
+    if (!builder.isNull()) {
+      TF_LITE_ENSURE(logging_context, webnn_operands.at(input_tensor_id).as<bool>());
       if (pool_params->filter_height == 1 && pool_params->filter_width == 1) {
         // Only do activation.
-        output = webnn_operands[input_tensor_id];
+        webnn_operands.insert(std::make_pair(output_tensor_id, webnn_operands.at(input_tensor_id)));
       } else {
-        wnn::Pool2dOptions options;
-        options.autoPad = auto_pad;
         std::vector<int32_t> strides = {
             pool_params->stride_height, pool_params->stride_width};
-        options.strides = strides.data();
-        options.stridesCount = strides.size();
         std::vector<int32_t> windowDimensions = {
             pool_params->filter_height, pool_params->filter_width};
-        options.windowDimensions = windowDimensions.data();
-        options.windowDimensionsCount = windowDimensions.size();
-        options.layout = wnn::InputOperandLayout::Nhwc;
-        output = builder.AveragePool2d(webnn_operands[input_tensor_id], &options);
+
+        emscripten::val options = emscripten::val::object();
+        options.set("autoPad", emscripten::val(auto_pad));
+        options.set("strides", emscripten::val::array(strides));
+        options.set("windowDimensions", emscripten::val::array(windowDimensions));
+        options.set("layout", emscripten::val("nhwc"));
+        webnn_operands.insert(std::make_pair(
+            output_tensor_id,
+            builder.call<emscripten::val>("averagePool2d",
+                                           webnn_operands.at(input_tensor_id),
+                                           options)));
       }
-      webnn_operands[output_tensor_id] = output;
-      TF_LITE_ENSURE(logging_context, webnn_operands[output_tensor_id]);
+      TF_LITE_ENSURE(logging_context, webnn_operands.at(output_tensor_id).as<bool>());
     }
 
     TF_LITE_ENSURE_STATUS(VisitActivation(
@@ -1247,167 +1246,167 @@ class Subgraph {
     return kTfLiteOk;
   }
 
-  static TfLiteStatus VisitMaxPool2DNode(
-      const wnn::GraphBuilder& builder, TfLiteContext* logging_context, int node_index,
-      TfLiteNode* node, const TfLiteTensor* tensors,
-      const TfLitePoolParams* pool_params,
-      std::vector<wnn::Operand>& webnn_operands,
-      std::vector<std::unique_ptr<char>>& constant_buffers) {
-    TF_LITE_ENSURE_STATUS(
-        CheckNumInputsAndOutputs(logging_context, node, 1, 1, node_index));
+  // static TfLiteStatus VisitMaxPool2DNode(
+  //     const wnn::GraphBuilder& builder, TfLiteContext* logging_context, int node_index,
+  //     TfLiteNode* node, const TfLiteTensor* tensors,
+  //     const TfLitePoolParams* pool_params,
+  //     std::vector<wnn::Operand>& webnn_operands,
+  //     std::vector<std::unique_ptr<char>>& constant_buffers) {
+  //   TF_LITE_ENSURE_STATUS(
+  //       CheckNumInputsAndOutputs(logging_context, node, 1, 1, node_index));
 
-    const int input_tensor_id = node->inputs->data[0];
-    const TfLiteTensor& input_tensor = tensors[input_tensor_id];
-    TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
-        logging_context, input_tensor, input_tensor_id, node_index));
-    TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
-        logging_context, input_tensor, input_tensor_id, node_index));
+  //   const int input_tensor_id = node->inputs->data[0];
+  //   const TfLiteTensor& input_tensor = tensors[input_tensor_id];
+  //   TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
+  //       logging_context, input_tensor, input_tensor_id, node_index));
+  //   TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
+  //       logging_context, input_tensor, input_tensor_id, node_index));
 
-    const int output_tensor_id = node->outputs->data[0];
-    const TfLiteTensor& output_tensor = tensors[output_tensor_id];
-    TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
-        logging_context, output_tensor, output_tensor_id, node_index));
-    TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
-        logging_context, output_tensor, output_tensor_id, node_index));
+  //   const int output_tensor_id = node->outputs->data[0];
+  //   const TfLiteTensor& output_tensor = tensors[output_tensor_id];
+  //   TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
+  //       logging_context, output_tensor, output_tensor_id, node_index));
+  //   TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
+  //       logging_context, output_tensor, output_tensor_id, node_index));
 
-    TF_LITE_ENSURE_STATUS(
-        CheckPoolingParams(logging_context, pool_params, node_index));
+  //   TF_LITE_ENSURE_STATUS(
+  //       CheckPoolingParams(logging_context, pool_params, node_index));
 
-    wnn::AutoPad auto_pad;
-    TF_LITE_ENSURE_STATUS(CalculatePadding(
-        logging_context, pool_params->padding, auto_pad, node_index));
+  //   wnn::AutoPad auto_pad;
+  //   TF_LITE_ENSURE_STATUS(CalculatePadding(
+  //       logging_context, pool_params->padding, auto_pad, node_index));
 
-    if (builder) {
-      wnn::Operand output;
-      wnn::Pool2dOptions options;
-      options.autoPad = auto_pad;
-      std::vector<int32_t> strides = {
-          pool_params->stride_height, pool_params->stride_width};
-      options.strides = strides.data();
-      options.stridesCount = strides.size();
-      std::vector<int32_t> windowDimensions = {
-          pool_params->filter_height, pool_params->filter_width};
-      options.windowDimensions = windowDimensions.data();
-      options.windowDimensionsCount = windowDimensions.size();
-      options.layout = wnn::InputOperandLayout::Nhwc;
-      TF_LITE_ENSURE(logging_context, webnn_operands[input_tensor_id]);
-      output = builder.MaxPool2d(webnn_operands[input_tensor_id], &options);
-      webnn_operands[output_tensor_id] = output;
-      TF_LITE_ENSURE(logging_context, webnn_operands[output_tensor_id]);
-    }
+  //   if (builder) {
+  //     wnn::Operand output;
+  //     wnn::Pool2dOptions options;
+  //     options.autoPad = auto_pad;
+  //     std::vector<int32_t> strides = {
+  //         pool_params->stride_height, pool_params->stride_width};
+  //     options.strides = strides.data();
+  //     options.stridesCount = strides.size();
+  //     std::vector<int32_t> windowDimensions = {
+  //         pool_params->filter_height, pool_params->filter_width};
+  //     options.windowDimensions = windowDimensions.data();
+  //     options.windowDimensionsCount = windowDimensions.size();
+  //     options.layout = wnn::InputOperandLayout::Nhwc;
+  //     TF_LITE_ENSURE(logging_context, webnn_operands[input_tensor_id]);
+  //     output = builder.MaxPool2d(webnn_operands[input_tensor_id], &options);
+  //     webnn_operands[output_tensor_id] = output;
+  //     TF_LITE_ENSURE(logging_context, webnn_operands[output_tensor_id]);
+  //   }
 
-    TF_LITE_ENSURE_STATUS(VisitActivation(
-          builder, logging_context, node_index, output_tensor_id, output_tensor_id,
-          pool_params->activation, webnn_operands, constant_buffers));
+  //   TF_LITE_ENSURE_STATUS(VisitActivation(
+  //         builder, logging_context, node_index, output_tensor_id, output_tensor_id,
+  //         pool_params->activation, webnn_operands, constant_buffers));
 
-    return kTfLiteOk;
-  }
+  //   return kTfLiteOk;
+  // }
 
-  static TfLiteStatus VisitMeanNode(
-      const wnn::GraphBuilder& builder, TfLiteContext* logging_context, int node_index,
-      TfLiteNode* node, const TfLiteTensor* tensors,
-      const TfLiteReducerParams* reducer_params,
-      std::vector<wnn::Operand>& webnn_operands,
-      std::vector<std::unique_ptr<char>>& constant_buffers) {
-    TF_LITE_ENSURE_STATUS(
-        CheckNumInputsAndOutputs(logging_context, node, 2, 1, node_index));
+  // static TfLiteStatus VisitMeanNode(
+  //     const wnn::GraphBuilder& builder, TfLiteContext* logging_context, int node_index,
+  //     TfLiteNode* node, const TfLiteTensor* tensors,
+  //     const TfLiteReducerParams* reducer_params,
+  //     std::vector<wnn::Operand>& webnn_operands,
+  //     std::vector<std::unique_ptr<char>>& constant_buffers) {
+  //   TF_LITE_ENSURE_STATUS(
+  //       CheckNumInputsAndOutputs(logging_context, node, 2, 1, node_index));
 
-    const int input_tensor_id = node->inputs->data[0];
-    const TfLiteTensor& input_tensor = tensors[input_tensor_id];
-    TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
-        logging_context, input_tensor, input_tensor_id, node_index));
-    TF_LITE_ENSURE_STATUS(CheckTensorShape(logging_context, input_tensor, 4,
-                                           input_tensor_id));
-    TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
-        logging_context, input_tensor, input_tensor_id, node_index));
+  //   const int input_tensor_id = node->inputs->data[0];
+  //   const TfLiteTensor& input_tensor = tensors[input_tensor_id];
+  //   TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
+  //       logging_context, input_tensor, input_tensor_id, node_index));
+  //   TF_LITE_ENSURE_STATUS(CheckTensorShape(logging_context, input_tensor, 4,
+  //                                          input_tensor_id));
+  //   TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
+  //       logging_context, input_tensor, input_tensor_id, node_index));
 
-    const int axes_tensor_id = node->inputs->data[1];
-    const TfLiteTensor& axes_tensor = tensors[axes_tensor_id];
-    TF_LITE_ENSURE_STATUS(CheckTensorType(logging_context, axes_tensor,
-                                          kTfLiteInt32, axes_tensor_id,
-                                          node_index));
-    TF_LITE_ENSURE_STATUS(CheckAxesTensorShape(
-        logging_context, axes_tensor, axes_tensor_id, node_index));
-    TF_LITE_ENSURE_STATUS(CheckTensorStaticAllocation(
-        logging_context, axes_tensor, axes_tensor_id, node_index));
+  //   const int axes_tensor_id = node->inputs->data[1];
+  //   const TfLiteTensor& axes_tensor = tensors[axes_tensor_id];
+  //   TF_LITE_ENSURE_STATUS(CheckTensorType(logging_context, axes_tensor,
+  //                                         kTfLiteInt32, axes_tensor_id,
+  //                                         node_index));
+  //   TF_LITE_ENSURE_STATUS(CheckAxesTensorShape(
+  //       logging_context, axes_tensor, axes_tensor_id, node_index));
+  //   TF_LITE_ENSURE_STATUS(CheckTensorStaticAllocation(
+  //       logging_context, axes_tensor, axes_tensor_id, node_index));
 
-    if (axes_tensor.dims->data[0] != 2) {
-      TF_LITE_MAYBE_KERNEL_LOG(
-          logging_context,
-          "unsupported MEAN reduction along %d axes in node %d",
-          axes_tensor.dims->data[0], node_index);
-      return kTfLiteError;
-    }
+  //   if (axes_tensor.dims->data[0] != 2) {
+  //     TF_LITE_MAYBE_KERNEL_LOG(
+  //         logging_context,
+  //         "unsupported MEAN reduction along %d axes in node %d",
+  //         axes_tensor.dims->data[0], node_index);
+  //     return kTfLiteError;
+  //   }
 
-    const int32_t* axes_data =
-        reinterpret_cast<const int32_t*>(axes_tensor.data.data);
-    if (std::min(axes_data[0], axes_data[1]) != 1 ||
-        std::max(axes_data[0], axes_data[1]) != 2) {
-      TF_LITE_MAYBE_KERNEL_LOG(logging_context,
-                               "unsupported MEAN reduction along non-spatial "
-                               "axes %d and %d in node %d",
-                               std::min(axes_data[0], axes_data[1]),
-                               std::max(axes_data[0], axes_data[1]),
-                               node_index);
-      return kTfLiteError;
-    }
+  //   const int32_t* axes_data =
+  //       reinterpret_cast<const int32_t*>(axes_tensor.data.data);
+  //   if (std::min(axes_data[0], axes_data[1]) != 1 ||
+  //       std::max(axes_data[0], axes_data[1]) != 2) {
+  //     TF_LITE_MAYBE_KERNEL_LOG(logging_context,
+  //                              "unsupported MEAN reduction along non-spatial "
+  //                              "axes %d and %d in node %d",
+  //                              std::min(axes_data[0], axes_data[1]),
+  //                              std::max(axes_data[0], axes_data[1]),
+  //                              node_index);
+  //     return kTfLiteError;
+  //   }
 
-    const int output_tensor_id = node->outputs->data[0];
-    const TfLiteTensor& output_tensor = tensors[output_tensor_id];
-    TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
-        logging_context, output_tensor, output_tensor_id, node_index));
-    const int expected_output_dims = reducer_params->keep_dims ? 4 : 2;
-    TF_LITE_ENSURE_STATUS(CheckTensorShape(logging_context, output_tensor,
-                                           expected_output_dims,
-                                           output_tensor_id));
-    TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
-        logging_context, output_tensor, output_tensor_id, node_index));
+  //   const int output_tensor_id = node->outputs->data[0];
+  //   const TfLiteTensor& output_tensor = tensors[output_tensor_id];
+  //   TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
+  //       logging_context, output_tensor, output_tensor_id, node_index));
+  //   const int expected_output_dims = reducer_params->keep_dims ? 4 : 2;
+  //   TF_LITE_ENSURE_STATUS(CheckTensorShape(logging_context, output_tensor,
+  //                                          expected_output_dims,
+  //                                          output_tensor_id));
+  //   TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
+  //       logging_context, output_tensor, output_tensor_id, node_index));
 
-    if (builder) {
-      wnn::Operand output;
-      wnn::ReduceOptions reduceOptions;
-      reduceOptions.axes = axes_data;
-      reduceOptions.axesCount = axes_tensor.dims->data[0];
-      reduceOptions.keepDimensions = reducer_params->keep_dims;
-      TF_LITE_ENSURE(logging_context, webnn_operands[input_tensor_id]);
-      output = builder.ReduceMean(webnn_operands[input_tensor_id], &reduceOptions);
-      webnn_operands[output_tensor_id] = output;
-      TF_LITE_ENSURE(logging_context, webnn_operands[output_tensor_id]);
-    }
+  //   if (builder) {
+  //     wnn::Operand output;
+  //     wnn::ReduceOptions reduceOptions;
+  //     reduceOptions.axes = axes_data;
+  //     reduceOptions.axesCount = axes_tensor.dims->data[0];
+  //     reduceOptions.keepDimensions = reducer_params->keep_dims;
+  //     TF_LITE_ENSURE(logging_context, webnn_operands[input_tensor_id]);
+  //     output = builder.ReduceMean(webnn_operands[input_tensor_id], &reduceOptions);
+  //     webnn_operands[output_tensor_id] = output;
+  //     TF_LITE_ENSURE(logging_context, webnn_operands[output_tensor_id]);
+  //   }
 
-    return kTfLiteOk;
-  }
+  //   return kTfLiteOk;
+  // }
 
-  static TfLiteStatus VisitConcatenationNode(
-      const wnn::GraphBuilder& builder, TfLiteContext* logging_context, int node_index,
-      TfLiteNode* node, const TfLiteTensor* tensors,
-      const TfLiteConcatenationParams* concat_params,
-      std::vector<wnn::Operand>& webnn_operands,
-      std::vector<std::unique_ptr<char>>& constant_buffers) {
-    size_t input_size = node->inputs->size;
-    const TfLiteTensor& first_input_tensor = tensors[node->inputs->data[0]];
-    uint32_t axis = concat_params->axis < 0
-                     ? first_input_tensor.dims->size + concat_params->axis
-                     : concat_params->axis;
-    if (builder) {
-      std::vector<wnn::Operand> input_operands;
-      for (size_t i = 0; i < input_size; ++i) {
-        TF_LITE_ENSURE(logging_context, webnn_operands[node->inputs->data[i]]);
-        input_operands.push_back(webnn_operands[node->inputs->data[i]]);
-      }
-      wnn::Operand output_operand = builder.Concat(input_operands.size(), input_operands.data(), axis);
-      webnn_operands[node->outputs->data[0]] = output_operand;
-      TF_LITE_ENSURE(logging_context, webnn_operands[node->outputs->data[0]]);
-    }
-    return kTfLiteOk;
-  }
+  // static TfLiteStatus VisitConcatenationNode(
+  //     const wnn::GraphBuilder& builder, TfLiteContext* logging_context, int node_index,
+  //     TfLiteNode* node, const TfLiteTensor* tensors,
+  //     const TfLiteConcatenationParams* concat_params,
+  //     std::vector<wnn::Operand>& webnn_operands,
+  //     std::vector<std::unique_ptr<char>>& constant_buffers) {
+  //   size_t input_size = node->inputs->size;
+  //   const TfLiteTensor& first_input_tensor = tensors[node->inputs->data[0]];
+  //   uint32_t axis = concat_params->axis < 0
+  //                    ? first_input_tensor.dims->size + concat_params->axis
+  //                    : concat_params->axis;
+  //   if (builder) {
+  //     std::vector<wnn::Operand> input_operands;
+  //     for (size_t i = 0; i < input_size; ++i) {
+  //       TF_LITE_ENSURE(logging_context, webnn_operands[node->inputs->data[i]]);
+  //       input_operands.push_back(webnn_operands[node->inputs->data[i]]);
+  //     }
+  //     wnn::Operand output_operand = builder.Concat(input_operands.size(), input_operands.data(), axis);
+  //     webnn_operands[node->outputs->data[0]] = output_operand;
+  //     TF_LITE_ENSURE(logging_context, webnn_operands[node->outputs->data[0]]);
+  //   }
+  //   return kTfLiteOk;
+  // }
 
   static TfLiteStatus VisitConv2DNode(
-      const wnn::GraphBuilder& builder, TfLiteContext* logging_context, int node_index,
+      const emscripten::val& builder, TfLiteContext* logging_context, int node_index,
       TfLiteNode* node, const TfLiteTensor* tensors,
       const TfLiteConvParams* conv_params,
       const std::unordered_set<int>& quasi_static_tensors,
-      std::vector<wnn::Operand>& webnn_operands,
+      std::unordered_map<int, emscripten::val>& webnn_operands,
       std::vector<std::unique_ptr<char>>& constant_buffers) {
     TF_LITE_ENSURE_STATUS(
         CheckConvolutionParams(logging_context, conv_params, node_index));
@@ -1458,139 +1457,137 @@ class Subgraph {
     TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
         logging_context, output_tensor, output_tensor_id, node_index));
 
-    wnn::AutoPad auto_pad;
+    std::string auto_pad;
     TF_LITE_ENSURE_STATUS(CalculatePadding(
         logging_context, conv_params->padding, auto_pad, node_index));
 
-    if (builder) {
-      wnn::Conv2dOptions options;
-      options.autoPad = auto_pad;
+    if (!builder.isNull()) {
       std::vector<int32_t> strides = {
           conv_params->stride_height, conv_params->stride_width};
-      options.strides = strides.data();
-      options.stridesCount = strides.size();
       std::vector<int32_t> dilations = {
           conv_params->dilation_height_factor, conv_params->dilation_width_factor};
-      options.dilations = dilations.data();
-      options.dilationsCount = dilations.size();
-      options.inputLayout = wnn::InputOperandLayout::Nhwc;
-      options.filterLayout = wnn::Conv2dFilterOperandLayout::Ohwi;
-      TF_LITE_ENSURE(logging_context, webnn_operands[input_tensor_id]);
-      TF_LITE_ENSURE(logging_context, webnn_operands[filter_tensor_id]);
+
+      emscripten::val options = emscripten::val::object();
+      options.set("autoPad", emscripten::val(auto_pad));
+      options.set("strides", emscripten::val::array(strides));
+      options.set("dilations", emscripten::val::array(dilations));
+      options.set("inputLayout", emscripten::val("nhwc"));
+      options.set("filterLayout", emscripten::val("ohwi"));
+      TF_LITE_ENSURE(logging_context, webnn_operands.at(input_tensor_id).as<bool>());
+      TF_LITE_ENSURE(logging_context, webnn_operands.at(filter_tensor_id).as<bool>());
       if (bias_tensor_id >= 0) {
-        TF_LITE_ENSURE(logging_context, webnn_operands[bias_tensor_id]);
-        options.bias = webnn_operands[bias_tensor_id];
+        TF_LITE_ENSURE(logging_context, webnn_operands.at(bias_tensor_id).as<bool>());
+        options.set("bias", webnn_operands.at(bias_tensor_id));
       }
-      wnn::FusionOperator activation_operator;
+
+      emscripten::val activation_operator = emscripten::val::object();
       if (conv_params->activation != kTfLiteActNone) {
         TF_LITE_ENSURE_STATUS(GetActivation(builder, logging_context, node_index,
             conv_params->activation, activation_operator));
-        options.activation = activation_operator;
+        options.set("activation", activation_operator);
       }
-      wnn::Operand output =
-          builder.Conv2d(webnn_operands[input_tensor_id],
-                         webnn_operands[filter_tensor_id],
-                         &options);
-      webnn_operands[output_tensor_id] = output;
-      TF_LITE_ENSURE(logging_context, webnn_operands[output_tensor_id]);
+      emscripten::val output = builder.call<emscripten::val>("conv2d",
+          webnn_operands.at(input_tensor_id), webnn_operands.at(filter_tensor_id), options);
+      webnn_operands.insert(std::make_pair(output_tensor_id, output));
+      TF_LITE_ENSURE(logging_context, webnn_operands.at(output_tensor_id).as<bool>());
     }
 
     return kTfLiteOk;
   }
 
-  static TfLiteStatus VisitMediaPipeDeconvolutionNode(
-      const wnn::GraphBuilder& builder, TfLiteContext* logging_context, int node_index,
-      TfLiteNode* node, const TfLiteTensor* tensors,
-      const TfLiteTransposeConvParams* deconv_params,
-      const std::unordered_set<int>& quasi_static_tensors,
-      std::vector<wnn::Operand>& webnn_operands) {
-    TF_LITE_ENSURE_STATUS(
-        CheckNumInputsAndOutputs(logging_context, node, 3, 1, node_index));
+  // static TfLiteStatus VisitMediaPipeDeconvolutionNode(
+  //     const wnn::GraphBuilder& builder, TfLiteContext* logging_context, int node_index,
+  //     TfLiteNode* node, const TfLiteTensor* tensors,
+  //     const TfLiteTransposeConvParams* deconv_params,
+  //     const std::unordered_set<int>& quasi_static_tensors,
+  //     std::vector<wnn::Operand>& webnn_operands) {
+  //   TF_LITE_ENSURE_STATUS(
+  //       CheckNumInputsAndOutputs(logging_context, node, 3, 1, node_index));
 
-    const int input_tensor_id = node->inputs->data[0];
-    const TfLiteTensor& input_tensor = tensors[input_tensor_id];
-    TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
-        logging_context, input_tensor, input_tensor_id, node_index));
-    TF_LITE_ENSURE_STATUS(CheckTensorShape(logging_context, input_tensor, 4,
-                                           input_tensor_id));
-    TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
-        logging_context, input_tensor, input_tensor_id, node_index));
+  //   const int input_tensor_id = node->inputs->data[0];
+  //   const TfLiteTensor& input_tensor = tensors[input_tensor_id];
+  //   TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
+  //       logging_context, input_tensor, input_tensor_id, node_index));
+  //   TF_LITE_ENSURE_STATUS(CheckTensorShape(logging_context, input_tensor, 4,
+  //                                          input_tensor_id));
+  //   TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
+  //       logging_context, input_tensor, input_tensor_id, node_index));
 
-    const int filter_tensor_id = node->inputs->data[1];
-    const TfLiteTensor& filter_tensor = tensors[filter_tensor_id];
-    TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
-        logging_context, filter_tensor, filter_tensor_id, node_index));
-    TF_LITE_ENSURE_STATUS(CheckTensorShape(logging_context, filter_tensor, 4,
-                                           filter_tensor_id));
-    if (quasi_static_tensors.count(filter_tensor_id) == 0) {
-      TF_LITE_ENSURE_STATUS(CheckTensorStaticAllocation(
-          logging_context, filter_tensor, filter_tensor_id, node_index));
-    }
+  //   const int filter_tensor_id = node->inputs->data[1];
+  //   const TfLiteTensor& filter_tensor = tensors[filter_tensor_id];
+  //   TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
+  //       logging_context, filter_tensor, filter_tensor_id, node_index));
+  //   TF_LITE_ENSURE_STATUS(CheckTensorShape(logging_context, filter_tensor, 4,
+  //                                          filter_tensor_id));
+  //   if (quasi_static_tensors.count(filter_tensor_id) == 0) {
+  //     TF_LITE_ENSURE_STATUS(CheckTensorStaticAllocation(
+  //         logging_context, filter_tensor, filter_tensor_id, node_index));
+  //   }
 
-    const int bias_tensor_id = node->inputs->data[2];
-    const TfLiteTensor& bias_tensor = tensors[bias_tensor_id];
-    TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
-        logging_context, bias_tensor, bias_tensor_id, node_index));
-    TF_LITE_ENSURE_STATUS(CheckTensorShape(logging_context, bias_tensor, 1,
-                                           bias_tensor_id));
-    if (quasi_static_tensors.count(bias_tensor_id) == 0) {
-      TF_LITE_ENSURE_STATUS(CheckTensorStaticAllocation(
-          logging_context, bias_tensor, bias_tensor_id, node_index));
-    }
+  //   const int bias_tensor_id = node->inputs->data[2];
+  //   const TfLiteTensor& bias_tensor = tensors[bias_tensor_id];
+  //   TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
+  //       logging_context, bias_tensor, bias_tensor_id, node_index));
+  //   TF_LITE_ENSURE_STATUS(CheckTensorShape(logging_context, bias_tensor, 1,
+  //                                          bias_tensor_id));
+  //   if (quasi_static_tensors.count(bias_tensor_id) == 0) {
+  //     TF_LITE_ENSURE_STATUS(CheckTensorStaticAllocation(
+  //         logging_context, bias_tensor, bias_tensor_id, node_index));
+  //   }
 
-    const int output_tensor_id = node->outputs->data[0];
-    const TfLiteTensor& output_tensor = tensors[output_tensor_id];
-    TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
-        logging_context, output_tensor, output_tensor_id, node_index));
-    TF_LITE_ENSURE_STATUS(CheckTensorShape(logging_context, output_tensor, 4,
-                                           output_tensor_id));
-    TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
-        logging_context, output_tensor, output_tensor_id, node_index));
+  //   const int output_tensor_id = node->outputs->data[0];
+  //   const TfLiteTensor& output_tensor = tensors[output_tensor_id];
+  //   TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
+  //       logging_context, output_tensor, output_tensor_id, node_index));
+  //   TF_LITE_ENSURE_STATUS(CheckTensorShape(logging_context, output_tensor, 4,
+  //                                          output_tensor_id));
+  //   TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
+  //       logging_context, output_tensor, output_tensor_id, node_index));
 
-    const int output_channels = filter_tensor.dims->data[0];
-    const int kernel_height = filter_tensor.dims->data[1];
-    const int kernel_width = filter_tensor.dims->data[2];
-    const int input_channels = filter_tensor.dims->data[3];
+  //   const int output_channels = filter_tensor.dims->data[0];
+  //   const int kernel_height = filter_tensor.dims->data[1];
+  //   const int kernel_width = filter_tensor.dims->data[2];
+  //   const int input_channels = filter_tensor.dims->data[3];
 
-    TF_LITE_ENSURE_STATUS(CheckMediaPipeTransposedConvolutionParams(
-        logging_context, deconv_params, node_index));
+  //   TF_LITE_ENSURE_STATUS(CheckMediaPipeTransposedConvolutionParams(
+  //       logging_context, deconv_params, node_index));
 
-    wnn::AutoPad auto_pad;
-    TF_LITE_ENSURE_STATUS(CalculatePadding(
-        logging_context, deconv_params->padding, auto_pad, node_index));
+  //   wnn::AutoPad auto_pad;
+  //   TF_LITE_ENSURE_STATUS(CalculatePadding(
+  //       logging_context, deconv_params->padding, auto_pad, node_index));
 
-    if (builder) {
-      wnn::ConvTranspose2dOptions options;
-      options.autoPad = auto_pad;
-      std::vector<int32_t> strides = {
-          deconv_params->stride_height, deconv_params->stride_width};
-      options.strides = strides.data();
-      options.stridesCount = strides.size();
-      options.inputLayout = wnn::InputOperandLayout::Nhwc;
-      options.filterLayout = wnn::ConvTranspose2dFilterOperandLayout::Ohwi;
-      TF_LITE_ENSURE(logging_context, webnn_operands[input_tensor_id]);
-      TF_LITE_ENSURE(logging_context, webnn_operands[filter_tensor_id]);
-      if (bias_tensor_id >= 0) {
-        TF_LITE_ENSURE(logging_context, webnn_operands[bias_tensor_id]);
-        options.bias = webnn_operands[bias_tensor_id];
-      }
-      wnn::Operand output =
-          builder.ConvTranspose2d(webnn_operands[input_tensor_id],
-                         webnn_operands[filter_tensor_id],
-                         &options);
-      webnn_operands[output_tensor_id] = output;
-      TF_LITE_ENSURE(logging_context, webnn_operands[output_tensor_id]);
-    }
+  //   if (builder) {
+  //     wnn::ConvTranspose2dOptions options;
+  //     options.autoPad = auto_pad;
+  //     std::vector<int32_t> strides = {
+  //         deconv_params->stride_height, deconv_params->stride_width};
+  //     options.strides = strides.data();
+  //     options.stridesCount = strides.size();
+  //     options.inputLayout = wnn::InputOperandLayout::Nhwc;
+  //     options.filterLayout = wnn::ConvTranspose2dFilterOperandLayout::Ohwi;
+  //     TF_LITE_ENSURE(logging_context, webnn_operands[input_tensor_id]);
+  //     TF_LITE_ENSURE(logging_context, webnn_operands[filter_tensor_id]);
+  //     if (bias_tensor_id >= 0) {
+  //       TF_LITE_ENSURE(logging_context, webnn_operands[bias_tensor_id]);
+  //       options.bias = webnn_operands[bias_tensor_id];
+  //     }
+  //     wnn::Operand output =
+  //         builder.ConvTranspose2d(webnn_operands[input_tensor_id],
+  //                        webnn_operands[filter_tensor_id],
+  //                        &options);
+  //     webnn_operands[output_tensor_id] = output;
+  //     TF_LITE_ENSURE(logging_context, webnn_operands[output_tensor_id]);
+  //   }
 
-    return kTfLiteOk;
-  }
+  //   return kTfLiteOk;
+  // }
 
   static TfLiteStatus VisitDepthwiseConv2DNode(
-      const wnn::GraphBuilder& builder, TfLiteContext* logging_context, int node_index,
+      const emscripten::val& builder, TfLiteContext* logging_context, int node_index,
       TfLiteNode* node, const TfLiteTensor* tensors,
       const TfLiteDepthwiseConvParams* dwconv_params,
       const std::unordered_set<int>& quasi_static_tensors,
-      std::vector<wnn::Operand>& webnn_operands,
+      std::unordered_map<int, emscripten::val>& webnn_operands,
       std::vector<std::unique_ptr<char>>& constant_buffers) {
     TF_LITE_ENSURE_STATUS(
         CheckNumInputsAndOutputs(logging_context, node, 3, 1, node_index));
@@ -1642,302 +1639,299 @@ class Subgraph {
     TF_LITE_ENSURE_STATUS(CheckDepthwiseConvolutionParams(
         logging_context, dwconv_params, output_channels, node_index));
 
-    wnn::AutoPad auto_pad;
+    std::string auto_pad;
     TF_LITE_ENSURE_STATUS(CalculatePadding(
         logging_context, dwconv_params->padding, auto_pad, node_index));
 
-    if (builder) {
-      wnn::Conv2dOptions options;
-      options.autoPad = auto_pad;
+    if (!builder.isNull()) {
       std::vector<int32_t> strides = {
           dwconv_params->stride_height, dwconv_params->stride_width};
-      options.strides = strides.data();
-      options.stridesCount = strides.size();
       std::vector<int32_t> dilations = {
           dwconv_params->dilation_height_factor, dwconv_params->dilation_width_factor};
-      options.dilations = dilations.data();
-      options.dilationsCount = dilations.size();
-      options.inputLayout = wnn::InputOperandLayout::Nhwc;
-      options.filterLayout = wnn::Conv2dFilterOperandLayout::Ihwo;
-      options.groups = output_channels / dwconv_params->depth_multiplier;
-      TF_LITE_ENSURE(logging_context, webnn_operands[input_tensor_id]);
-      TF_LITE_ENSURE(logging_context, webnn_operands[filter_tensor_id]);
 
+      emscripten::val options = emscripten::val::object();
+      options.set("autoPad", emscripten::val(auto_pad));
+      options.set("strides", emscripten::val::array(strides));
+      options.set("dilations", emscripten::val::array(dilations));
+      options.set("inputLayout", emscripten::val("nhwc"));
+      options.set("filterLayout", emscripten::val("ihwo"));
+      options.set("groups", emscripten::val(output_channels / dwconv_params->depth_multiplier));
+      TF_LITE_ENSURE(logging_context, webnn_operands.at(input_tensor_id).as<bool>());
+      TF_LITE_ENSURE(logging_context, webnn_operands.at(filter_tensor_id).as<bool>());
       if (bias_tensor_id >= 0) {
-        TF_LITE_ENSURE(logging_context, webnn_operands[bias_tensor_id]);
-        options.bias = webnn_operands[bias_tensor_id];
+        TF_LITE_ENSURE(logging_context, webnn_operands.at(bias_tensor_id).as<bool>());
+        options.set("bias", webnn_operands.at(bias_tensor_id));
       }
-      wnn::FusionOperator activation_operator;
+
+      emscripten::val activation_operator = emscripten::val::object();
       if (dwconv_params->activation != kTfLiteActNone) {
         TF_LITE_ENSURE_STATUS(GetActivation(builder, logging_context, node_index,
             dwconv_params->activation, activation_operator));
-        options.activation = activation_operator;
+        options.set("activation", activation_operator);
       }
-      wnn::Operand output =
-          builder.Conv2d(webnn_operands[input_tensor_id],
-                         webnn_operands[filter_tensor_id],
-                         &options);
-      webnn_operands[output_tensor_id] = output;
-      TF_LITE_ENSURE(logging_context, webnn_operands[output_tensor_id]);
+      emscripten::val output = builder.call<emscripten::val>("conv2d",
+          webnn_operands.at(input_tensor_id), webnn_operands.at(filter_tensor_id), options);
+      webnn_operands.insert(std::make_pair(output_tensor_id, output));
+      TF_LITE_ENSURE(logging_context, webnn_operands.at(output_tensor_id).as<bool>());
     }
 
     return kTfLiteOk;
   }
 
-  static TfLiteStatus VisitFullyConnectedNode(
-      const wnn::GraphBuilder& builder, TfLiteContext* logging_context, int node_index,
-      TfLiteNode* node, const TfLiteTensor* tensors,
-      const TfLiteFullyConnectedParams* fc_params,
-      const std::unordered_set<int>& quasi_static_tensors,
-      std::vector<wnn::Operand>& webnn_operands,
-      std::vector<std::unique_ptr<char>>& constant_buffers) {
-    TF_LITE_ENSURE_STATUS(
-        CheckFullyConnectedParams(logging_context, fc_params, node_index));
-    TF_LITE_ENSURE_STATUS(
-        CheckNumInputsAndOutputs(logging_context, node, 2, 3, 1, node_index));
+  // static TfLiteStatus VisitFullyConnectedNode(
+  //     const wnn::GraphBuilder& builder, TfLiteContext* logging_context, int node_index,
+  //     TfLiteNode* node, const TfLiteTensor* tensors,
+  //     const TfLiteFullyConnectedParams* fc_params,
+  //     const std::unordered_set<int>& quasi_static_tensors,
+  //     std::vector<wnn::Operand>& webnn_operands,
+  //     std::vector<std::unique_ptr<char>>& constant_buffers) {
+  //   TF_LITE_ENSURE_STATUS(
+  //       CheckFullyConnectedParams(logging_context, fc_params, node_index));
+  //   TF_LITE_ENSURE_STATUS(
+  //       CheckNumInputsAndOutputs(logging_context, node, 2, 3, 1, node_index));
 
-    const int input_tensor_id = node->inputs->data[0];
-    const TfLiteTensor& input_tensor = tensors[input_tensor_id];
-    TF_LITE_ENSURE_STATUS(CheckTensorFloat32OrQInt8Type(
-        logging_context, input_tensor, input_tensor_id, node_index));
-    TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
-        logging_context, input_tensor, input_tensor_id, node_index));
+  //   const int input_tensor_id = node->inputs->data[0];
+  //   const TfLiteTensor& input_tensor = tensors[input_tensor_id];
+  //   TF_LITE_ENSURE_STATUS(CheckTensorFloat32OrQInt8Type(
+  //       logging_context, input_tensor, input_tensor_id, node_index));
+  //   TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
+  //       logging_context, input_tensor, input_tensor_id, node_index));
 
-    const int filter_tensor_id = node->inputs->data[1];
-    const TfLiteTensor& filter_tensor = tensors[filter_tensor_id];
-    TF_LITE_ENSURE_STATUS(CheckTensorFloat32OrQInt8Type(
-        logging_context, filter_tensor, filter_tensor_id, node_index));
-    TF_LITE_ENSURE_STATUS(CheckTensorShape(logging_context, filter_tensor, 2,
-                                           filter_tensor_id));
-    if (quasi_static_tensors.count(filter_tensor_id) == 0) {
-      TF_LITE_ENSURE_STATUS(CheckTensorStaticAllocation(
-          logging_context, filter_tensor, filter_tensor_id, node_index));
-    }
+  //   const int filter_tensor_id = node->inputs->data[1];
+  //   const TfLiteTensor& filter_tensor = tensors[filter_tensor_id];
+  //   TF_LITE_ENSURE_STATUS(CheckTensorFloat32OrQInt8Type(
+  //       logging_context, filter_tensor, filter_tensor_id, node_index));
+  //   TF_LITE_ENSURE_STATUS(CheckTensorShape(logging_context, filter_tensor, 2,
+  //                                          filter_tensor_id));
+  //   if (quasi_static_tensors.count(filter_tensor_id) == 0) {
+  //     TF_LITE_ENSURE_STATUS(CheckTensorStaticAllocation(
+  //         logging_context, filter_tensor, filter_tensor_id, node_index));
+  //   }
 
-    int bias_tensor_id = -1;
-    if (node->inputs->size >= 3) {
-      bias_tensor_id = node->inputs->data[2];
-      if (bias_tensor_id >= 0) {
-        const TfLiteTensor& bias_tensor = tensors[bias_tensor_id];
-        TF_LITE_ENSURE_STATUS(CheckTensorFloat32OrQInt32Type(
-            logging_context, bias_tensor, bias_tensor_id, node_index));
-        TF_LITE_ENSURE_STATUS(CheckTensorShape(logging_context, bias_tensor, 1,
-                                               bias_tensor_id));
-        if (quasi_static_tensors.count(bias_tensor_id) == 0) {
-          TF_LITE_ENSURE_STATUS(CheckTensorStaticAllocation(
-              logging_context, bias_tensor, bias_tensor_id, node_index));
-        }
-      }
-    }
+  //   int bias_tensor_id = -1;
+  //   if (node->inputs->size >= 3) {
+  //     bias_tensor_id = node->inputs->data[2];
+  //     if (bias_tensor_id >= 0) {
+  //       const TfLiteTensor& bias_tensor = tensors[bias_tensor_id];
+  //       TF_LITE_ENSURE_STATUS(CheckTensorFloat32OrQInt32Type(
+  //           logging_context, bias_tensor, bias_tensor_id, node_index));
+  //       TF_LITE_ENSURE_STATUS(CheckTensorShape(logging_context, bias_tensor, 1,
+  //                                              bias_tensor_id));
+  //       if (quasi_static_tensors.count(bias_tensor_id) == 0) {
+  //         TF_LITE_ENSURE_STATUS(CheckTensorStaticAllocation(
+  //             logging_context, bias_tensor, bias_tensor_id, node_index));
+  //       }
+  //     }
+  //   }
 
-    const int output_tensor_id = node->outputs->data[0];
-    const TfLiteTensor& output_tensor = tensors[output_tensor_id];
-    TF_LITE_ENSURE_STATUS(CheckTensorFloat32OrQInt8Type(
-        logging_context, output_tensor, output_tensor_id, node_index));
-    TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
-        logging_context, output_tensor, output_tensor_id, node_index));
+  //   const int output_tensor_id = node->outputs->data[0];
+  //   const TfLiteTensor& output_tensor = tensors[output_tensor_id];
+  //   TF_LITE_ENSURE_STATUS(CheckTensorFloat32OrQInt8Type(
+  //       logging_context, output_tensor, output_tensor_id, node_index));
+  //   TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
+  //       logging_context, output_tensor, output_tensor_id, node_index));
 
-    const int32_t output_channels = filter_tensor.dims->data[0];
-    const int32_t input_channels = filter_tensor.dims->data[1];
+  //   const int32_t output_channels = filter_tensor.dims->data[0];
+  //   const int32_t input_channels = filter_tensor.dims->data[1];
 
-    if (input_tensor.dims->size == 0) {
-      TF_LITE_MAYBE_KERNEL_LOG(
-          logging_context,
-          "unexpected number of shape dimensions %d in tensor #%d",
-          input_tensor.dims->size, input_tensor_id);
-      return kTfLiteError;
-    }
-    const int32_t * input_dims_data = input_tensor.dims->data;
-    int32_t num_input_elements = 1;
-    for (int i = 0; i < input_tensor.dims->size; i++) {
-      if (input_dims_data[i] <= 0) {
-        TF_LITE_MAYBE_KERNEL_LOG(
-            logging_context, "invalid dimension #%d (%d) in tensor #%d", i,
-            input_dims_data[i], input_tensor_id);
-        return kTfLiteError;
-      }
-      num_input_elements *= input_dims_data[i];
-    }
+  //   if (input_tensor.dims->size == 0) {
+  //     TF_LITE_MAYBE_KERNEL_LOG(
+  //         logging_context,
+  //         "unexpected number of shape dimensions %d in tensor #%d",
+  //         input_tensor.dims->size, input_tensor_id);
+  //     return kTfLiteError;
+  //   }
+  //   const int32_t * input_dims_data = input_tensor.dims->data;
+  //   int32_t num_input_elements = 1;
+  //   for (int i = 0; i < input_tensor.dims->size; i++) {
+  //     if (input_dims_data[i] <= 0) {
+  //       TF_LITE_MAYBE_KERNEL_LOG(
+  //           logging_context, "invalid dimension #%d (%d) in tensor #%d", i,
+  //           input_dims_data[i], input_tensor_id);
+  //       return kTfLiteError;
+  //     }
+  //     num_input_elements *= input_dims_data[i];
+  //   }
 
-    if (fc_params->keep_num_dims) {
-      TF_LITE_ENSURE_STATUS(CheckTensorShape(logging_context, output_tensor,
-                                             input_tensor.dims->size,
-                                             output_tensor_id));
+  //   if (fc_params->keep_num_dims) {
+  //     TF_LITE_ENSURE_STATUS(CheckTensorShape(logging_context, output_tensor,
+  //                                            input_tensor.dims->size,
+  //                                            output_tensor_id));
 
-      for (int i = 0; i < input_tensor.dims->size - 1; i++) {
-        if (input_dims_data[i] != output_tensor.dims->data[i]) {
-          TF_LITE_MAYBE_KERNEL_LOG(
-              logging_context,
-              "mismatch in shape dimension %d (%d != %d) in input and output "
-              "tensors of FULLY_CONNECTED operator #%d",
-              i, input_dims_data[i], output_tensor.dims->data[i],
-              node_index);
-          return kTfLiteError;
-        }
-      }
-    } else {
-      if (num_input_elements % input_channels != 0) {
-        TF_LITE_MAYBE_KERNEL_LOG(
-            logging_context,
-            "number of elements in input tensor #%d in FULLY_CONNECTED "
-            "operator is not divisible by input channels (%d)",
-            input_tensor_id, input_channels);
-        return kTfLiteError;
-      }
+  //     for (int i = 0; i < input_tensor.dims->size - 1; i++) {
+  //       if (input_dims_data[i] != output_tensor.dims->data[i]) {
+  //         TF_LITE_MAYBE_KERNEL_LOG(
+  //             logging_context,
+  //             "mismatch in shape dimension %d (%d != %d) in input and output "
+  //             "tensors of FULLY_CONNECTED operator #%d",
+  //             i, input_dims_data[i], output_tensor.dims->data[i],
+  //             node_index);
+  //         return kTfLiteError;
+  //       }
+  //     }
+  //   } else {
+  //     if (num_input_elements % input_channels != 0) {
+  //       TF_LITE_MAYBE_KERNEL_LOG(
+  //           logging_context,
+  //           "number of elements in input tensor #%d in FULLY_CONNECTED "
+  //           "operator is not divisible by input channels (%d)",
+  //           input_tensor_id, input_channels);
+  //       return kTfLiteError;
+  //     }
 
-      TF_LITE_ENSURE_STATUS(CheckTensorShape(logging_context, output_tensor, 2,
-                                             output_tensor_id));
+  //     TF_LITE_ENSURE_STATUS(CheckTensorShape(logging_context, output_tensor, 2,
+  //                                            output_tensor_id));
 
-      if (output_tensor.dims->data[0] != num_input_elements / input_channels) {
-        TF_LITE_MAYBE_KERNEL_LOG(
-            logging_context,
-            "batch size %d in output tensor #%d in FULLY_CONNECTED operator "
-            "does not match batch size %d in reshaped input tensor #%d",
-            output_tensor.dims->data[0], output_tensor_id,
-            num_input_elements / input_channels, input_tensor_id);
-        return kTfLiteError;
-      }
-    }
+  //     if (output_tensor.dims->data[0] != num_input_elements / input_channels) {
+  //       TF_LITE_MAYBE_KERNEL_LOG(
+  //           logging_context,
+  //           "batch size %d in output tensor #%d in FULLY_CONNECTED operator "
+  //           "does not match batch size %d in reshaped input tensor #%d",
+  //           output_tensor.dims->data[0], output_tensor_id,
+  //           num_input_elements / input_channels, input_tensor_id);
+  //       return kTfLiteError;
+  //     }
+  //   }
 
-    if (output_tensor.dims->data[output_tensor.dims->size - 1] !=
-        output_channels) {
-      TF_LITE_MAYBE_KERNEL_LOG(
-          logging_context,
-          "number of channels %d in output tensor #%d does not match output "
-          "channels %d in filter tensor #%d",
-          output_tensor.dims->data[output_tensor.dims->size - 1],
-          output_tensor_id, output_channels, filter_tensor_id);
-      return kTfLiteError;
-    }
+  //   if (output_tensor.dims->data[output_tensor.dims->size - 1] !=
+  //       output_channels) {
+  //     TF_LITE_MAYBE_KERNEL_LOG(
+  //         logging_context,
+  //         "number of channels %d in output tensor #%d does not match output "
+  //         "channels %d in filter tensor #%d",
+  //         output_tensor.dims->data[output_tensor.dims->size - 1],
+  //         output_tensor_id, output_channels, filter_tensor_id);
+  //     return kTfLiteError;
+  //   }
 
-    if (builder) {
-      wnn::GemmOptions options;
-      options.aTranspose = false;
-      options.bTranspose = true;
-      if (bias_tensor_id >= 0) {
-        TF_LITE_ENSURE(logging_context, webnn_operands[bias_tensor_id]);
-        options.c = webnn_operands[bias_tensor_id];
-      }
-      TF_LITE_ENSURE(logging_context, webnn_operands[input_tensor_id]);
-      TF_LITE_ENSURE(logging_context, webnn_operands[filter_tensor_id]);
-      wnn::Operand output;
-      if (fc_params->keep_num_dims || input_tensor.dims->size != 2) {
-        // Reshape input to 2D tensor
-        const int32_t n_inputs = input_channels;
-        std::vector<int32_t> new_input_shape = {-1, n_inputs};
-        wnn::Operand reshaped_input =
-            builder.Reshape(webnn_operands[input_tensor_id],
-                            new_input_shape.data(), new_input_shape.size());
-        wnn::Operand gemm = builder.Gemm(reshaped_input,
-                                        webnn_operands[filter_tensor_id],
-                                        &options);
-        output = builder.Reshape(gemm, &output_tensor.dims->data[0],
-                                 output_tensor.dims->size);
-      } else {
-        output = builder.Gemm(webnn_operands[input_tensor_id],
-                              webnn_operands[filter_tensor_id], &options);
-      }
+  //   if (builder) {
+  //     wnn::GemmOptions options;
+  //     options.aTranspose = false;
+  //     options.bTranspose = true;
+  //     if (bias_tensor_id >= 0) {
+  //       TF_LITE_ENSURE(logging_context, webnn_operands[bias_tensor_id]);
+  //       options.c = webnn_operands[bias_tensor_id];
+  //     }
+  //     TF_LITE_ENSURE(logging_context, webnn_operands[input_tensor_id]);
+  //     TF_LITE_ENSURE(logging_context, webnn_operands[filter_tensor_id]);
+  //     wnn::Operand output;
+  //     if (fc_params->keep_num_dims || input_tensor.dims->size != 2) {
+  //       // Reshape input to 2D tensor
+  //       const int32_t n_inputs = input_channels;
+  //       std::vector<int32_t> new_input_shape = {-1, n_inputs};
+  //       wnn::Operand reshaped_input =
+  //           builder.Reshape(webnn_operands[input_tensor_id],
+  //                           new_input_shape.data(), new_input_shape.size());
+  //       wnn::Operand gemm = builder.Gemm(reshaped_input,
+  //                                       webnn_operands[filter_tensor_id],
+  //                                       &options);
+  //       output = builder.Reshape(gemm, &output_tensor.dims->data[0],
+  //                                output_tensor.dims->size);
+  //     } else {
+  //       output = builder.Gemm(webnn_operands[input_tensor_id],
+  //                             webnn_operands[filter_tensor_id], &options);
+  //     }
 
-      webnn_operands[output_tensor_id] = output;
-      TF_LITE_ENSURE(logging_context, webnn_operands[output_tensor_id]);
-    }
+  //     webnn_operands[output_tensor_id] = output;
+  //     TF_LITE_ENSURE(logging_context, webnn_operands[output_tensor_id]);
+  //   }
 
-    TF_LITE_ENSURE_STATUS(VisitActivation(
-        builder, logging_context, node_index, output_tensor_id, output_tensor_id,
-        fc_params->activation, webnn_operands, constant_buffers));
+  //   TF_LITE_ENSURE_STATUS(VisitActivation(
+  //       builder, logging_context, node_index, output_tensor_id, output_tensor_id,
+  //       fc_params->activation, webnn_operands, constant_buffers));
 
-    return kTfLiteOk;
-  }
+  //   return kTfLiteOk;
+  // }
 
-  static TfLiteStatus VisitHardSwishNode(
-      const wnn::GraphBuilder& builder, TfLiteContext* logging_context, int node_index,
-      TfLiteNode* node, const TfLiteTensor* tensors,
-      std::vector<wnn::Operand>& webnn_operands) {
-    TF_LITE_ENSURE_STATUS(
-        CheckNumInputsAndOutputs(logging_context, node, 1, 1, node_index));
+  // static TfLiteStatus VisitHardSwishNode(
+  //     const wnn::GraphBuilder& builder, TfLiteContext* logging_context, int node_index,
+  //     TfLiteNode* node, const TfLiteTensor* tensors,
+  //     std::vector<wnn::Operand>& webnn_operands) {
+  //   TF_LITE_ENSURE_STATUS(
+  //       CheckNumInputsAndOutputs(logging_context, node, 1, 1, node_index));
 
-    const TfLiteTensor& input_tensor = tensors[node->inputs->data[0]];
-    TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
-        logging_context, input_tensor, node->inputs->data[0], node_index));
-    TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
-        logging_context, input_tensor, node->inputs->data[0], node_index));
+  //   const TfLiteTensor& input_tensor = tensors[node->inputs->data[0]];
+  //   TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
+  //       logging_context, input_tensor, node->inputs->data[0], node_index));
+  //   TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
+  //       logging_context, input_tensor, node->inputs->data[0], node_index));
 
-    const TfLiteTensor& output_tensor = tensors[node->outputs->data[0]];
-    TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
-        logging_context, output_tensor, node->outputs->data[0], node_index));
-    TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
-        logging_context, output_tensor, node->outputs->data[0], node_index));
+  //   const TfLiteTensor& output_tensor = tensors[node->outputs->data[0]];
+  //   TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
+  //       logging_context, output_tensor, node->outputs->data[0], node_index));
+  //   TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
+  //       logging_context, output_tensor, node->outputs->data[0], node_index));
 
-    if (builder) {
-      TF_LITE_ENSURE(logging_context, webnn_operands[node->inputs->data[0]]);
-      webnn_operands[node->outputs->data[0]] = builder.HardSwish(webnn_operands[node->inputs->data[0]]);
-      TF_LITE_ENSURE(logging_context, webnn_operands[node->outputs->data[0]]);
-    }
+  //   if (builder) {
+  //     TF_LITE_ENSURE(logging_context, webnn_operands[node->inputs->data[0]]);
+  //     webnn_operands[node->outputs->data[0]] = builder.HardSwish(webnn_operands[node->inputs->data[0]]);
+  //     TF_LITE_ENSURE(logging_context, webnn_operands[node->outputs->data[0]]);
+  //   }
 
-    return kTfLiteOk;
-  }
+  //   return kTfLiteOk;
+  // }
 
-  static TfLiteStatus VisitLogisticNode(
-      const wnn::GraphBuilder& builder, TfLiteContext* logging_context, int node_index,
-      TfLiteNode* node, const TfLiteTensor* tensors,
-      std::vector<wnn::Operand>& webnn_operands) {
-    TF_LITE_ENSURE_STATUS(
-        CheckNumInputsAndOutputs(logging_context, node, 1, 1, node_index));
+  // static TfLiteStatus VisitLogisticNode(
+  //     const wnn::GraphBuilder& builder, TfLiteContext* logging_context, int node_index,
+  //     TfLiteNode* node, const TfLiteTensor* tensors,
+  //     std::vector<wnn::Operand>& webnn_operands) {
+  //   TF_LITE_ENSURE_STATUS(
+  //       CheckNumInputsAndOutputs(logging_context, node, 1, 1, node_index));
 
-    const TfLiteTensor& input_tensor = tensors[node->inputs->data[0]];
-    TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
-        logging_context, input_tensor, node->inputs->data[0], node_index));
-    TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
-        logging_context, input_tensor, node->inputs->data[0], node_index));
+  //   const TfLiteTensor& input_tensor = tensors[node->inputs->data[0]];
+  //   TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
+  //       logging_context, input_tensor, node->inputs->data[0], node_index));
+  //   TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
+  //       logging_context, input_tensor, node->inputs->data[0], node_index));
 
-    const TfLiteTensor& output_tensor = tensors[node->outputs->data[0]];
-    TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
-        logging_context, output_tensor, node->outputs->data[0], node_index));
-    TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
-        logging_context, output_tensor, node->outputs->data[0], node_index));
+  //   const TfLiteTensor& output_tensor = tensors[node->outputs->data[0]];
+  //   TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
+  //       logging_context, output_tensor, node->outputs->data[0], node_index));
+  //   TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
+  //       logging_context, output_tensor, node->outputs->data[0], node_index));
 
-    if (builder) {
-      TF_LITE_ENSURE(logging_context, webnn_operands[node->inputs->data[0]]);
-      webnn_operands[node->outputs->data[0]] = builder.Sigmoid(webnn_operands[node->inputs->data[0]]);
-      TF_LITE_ENSURE(logging_context, webnn_operands[node->outputs->data[0]]);
-    }
+  //   if (builder) {
+  //     TF_LITE_ENSURE(logging_context, webnn_operands[node->inputs->data[0]]);
+  //     webnn_operands[node->outputs->data[0]] = builder.Sigmoid(webnn_operands[node->inputs->data[0]]);
+  //     TF_LITE_ENSURE(logging_context, webnn_operands[node->outputs->data[0]]);
+  //   }
 
-    return kTfLiteOk;
-  }
+  //   return kTfLiteOk;
+  // }
 
-  static TfLiteStatus VisitReluNode(
-      const wnn::GraphBuilder& builder, TfLiteContext* logging_context, int node_index,
-      TfLiteNode* node, const TfLiteTensor* tensors,
-      std::vector<wnn::Operand>& webnn_operands) {
-    TF_LITE_ENSURE_STATUS(
-        CheckNumInputsAndOutputs(logging_context, node, 1, 1, node_index));
+  // static TfLiteStatus VisitReluNode(
+  //     const wnn::GraphBuilder& builder, TfLiteContext* logging_context, int node_index,
+  //     TfLiteNode* node, const TfLiteTensor* tensors,
+  //     std::vector<wnn::Operand>& webnn_operands) {
+  //   TF_LITE_ENSURE_STATUS(
+  //       CheckNumInputsAndOutputs(logging_context, node, 1, 1, node_index));
 
-    const TfLiteTensor& input_tensor = tensors[node->inputs->data[0]];
-    TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
-        logging_context, input_tensor, node->inputs->data[0], node_index));
-    TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
-        logging_context, input_tensor, node->inputs->data[0], node_index));
+  //   const TfLiteTensor& input_tensor = tensors[node->inputs->data[0]];
+  //   TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
+  //       logging_context, input_tensor, node->inputs->data[0], node_index));
+  //   TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
+  //       logging_context, input_tensor, node->inputs->data[0], node_index));
 
-    const TfLiteTensor& output_tensor = tensors[node->outputs->data[0]];
-    TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
-        logging_context, output_tensor, node->outputs->data[0], node_index));
-    TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
-        logging_context, output_tensor, node->outputs->data[0], node_index));
+  //   const TfLiteTensor& output_tensor = tensors[node->outputs->data[0]];
+  //   TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
+  //       logging_context, output_tensor, node->outputs->data[0], node_index));
+  //   TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
+  //       logging_context, output_tensor, node->outputs->data[0], node_index));
 
-    if (builder) {
-      TF_LITE_ENSURE(logging_context, webnn_operands[node->inputs->data[0]]);
-      webnn_operands[node->outputs->data[0]] = builder.Relu(webnn_operands[node->inputs->data[0]]);
-      TF_LITE_ENSURE(logging_context, webnn_operands[node->outputs->data[0]]);
-    }
+  //   if (builder) {
+  //     TF_LITE_ENSURE(logging_context, webnn_operands[node->inputs->data[0]]);
+  //     webnn_operands[node->outputs->data[0]] = builder.Relu(webnn_operands[node->inputs->data[0]]);
+  //     TF_LITE_ENSURE(logging_context, webnn_operands[node->outputs->data[0]]);
+  //   }
 
-    return kTfLiteOk;
-  }
+  //   return kTfLiteOk;
+  // }
 
   static TfLiteStatus VisitReshapeNode(
-      const wnn::GraphBuilder& builder, TfLiteContext* logging_context, int node_index,
+      const emscripten::val& builder, TfLiteContext* logging_context, int node_index,
       TfLiteNode* node, const TfLiteTensor* tensors,
       const TfLiteReshapeParams* reshape_params,
-      std::vector<wnn::Operand>& webnn_operands) {
+      std::unordered_map<int, emscripten::val>& webnn_operands) {
     switch (node->inputs->size) {
       case 1:
       case 2:
@@ -1984,93 +1978,98 @@ class Subgraph {
     TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
         logging_context, output_tensor, output_tensor_id, node_index));
 
-    if (builder) {
-      TF_LITE_ENSURE(logging_context, webnn_operands[input_tensor_id]);
-      webnn_operands[output_tensor_id] = builder.Reshape(
-          webnn_operands[input_tensor_id], &output_tensor.dims->data[0], output_tensor.dims->size);
-      TF_LITE_ENSURE(logging_context, webnn_operands[output_tensor_id]);
+    if (!builder.isNull()) {
+      TF_LITE_ENSURE(logging_context, webnn_operands.at(input_tensor_id).as<bool>());
+      std::vector<int> newShape;
+      newShape.assign(&output_tensor.dims->data[0],
+                      &output_tensor.dims->data[0] + output_tensor.dims->size);
+      webnn_operands.insert(std::make_pair(
+          output_tensor_id, builder.call<emscripten::val>(
+                                "reshape", webnn_operands.at(input_tensor_id),
+                                emscripten::val::array(newShape))));
+      TF_LITE_ENSURE(logging_context, webnn_operands.at(output_tensor_id).as<bool>());
     }
 
     return kTfLiteOk;
   }
 
-  static TfLiteStatus VisitResizeBilinearNode(
-      const wnn::GraphBuilder& builder, TfLiteContext* logging_context, int node_index,
-      TfLiteNode* node, const TfLiteTensor* tensors,
-      const TfLiteResizeBilinearParams* resize_params,
-      std::vector<wnn::Operand>& webnn_operands) {
-    TF_LITE_ENSURE_STATUS(
-        CheckNumInputsAndOutputs(logging_context, node, 2, 1, node_index));
+  // static TfLiteStatus VisitResizeBilinearNode(
+  //     const wnn::GraphBuilder& builder, TfLiteContext* logging_context, int node_index,
+  //     TfLiteNode* node, const TfLiteTensor* tensors,
+  //     const TfLiteResizeBilinearParams* resize_params,
+  //     std::vector<wnn::Operand>& webnn_operands) {
+  //   TF_LITE_ENSURE_STATUS(
+  //       CheckNumInputsAndOutputs(logging_context, node, 2, 1, node_index));
 
-    const int input_tensor_id = node->inputs->data[0];
-    const TfLiteTensor& input_tensor = tensors[input_tensor_id];
-    TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
-        logging_context, input_tensor, input_tensor_id, node_index));
-    TF_LITE_ENSURE_STATUS(CheckTensorShape(logging_context, input_tensor, 4,
-                                           input_tensor_id));
-    TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
-        logging_context, input_tensor, input_tensor_id, node_index));
+  //   const int input_tensor_id = node->inputs->data[0];
+  //   const TfLiteTensor& input_tensor = tensors[input_tensor_id];
+  //   TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
+  //       logging_context, input_tensor, input_tensor_id, node_index));
+  //   TF_LITE_ENSURE_STATUS(CheckTensorShape(logging_context, input_tensor, 4,
+  //                                          input_tensor_id));
+  //   TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
+  //       logging_context, input_tensor, input_tensor_id, node_index));
 
-    const int shape_tensor_id = node->inputs->data[1];
-    const TfLiteTensor& shape_tensor = tensors[shape_tensor_id];
-    TF_LITE_ENSURE_STATUS(CheckTensorType(logging_context, shape_tensor,
-                                          kTfLiteInt32, shape_tensor_id,
-                                          node_index));
-    TF_LITE_ENSURE_STATUS(CheckShapeTensorShape(
-        logging_context, shape_tensor, shape_tensor_id, node_index));
-    if (shape_tensor.dims->data[0] != 2) {
-      TF_LITE_MAYBE_KERNEL_LOG(
-          logging_context,
-          "unexpected number of dimensions %d in the output shape in node %d",
-          shape_tensor.dims->data[0], node_index);
-    }
-    TF_LITE_ENSURE_STATUS(CheckTensorStaticAllocation(
-        logging_context, shape_tensor, shape_tensor_id, node_index));
+  //   const int shape_tensor_id = node->inputs->data[1];
+  //   const TfLiteTensor& shape_tensor = tensors[shape_tensor_id];
+  //   TF_LITE_ENSURE_STATUS(CheckTensorType(logging_context, shape_tensor,
+  //                                         kTfLiteInt32, shape_tensor_id,
+  //                                         node_index));
+  //   TF_LITE_ENSURE_STATUS(CheckShapeTensorShape(
+  //       logging_context, shape_tensor, shape_tensor_id, node_index));
+  //   if (shape_tensor.dims->data[0] != 2) {
+  //     TF_LITE_MAYBE_KERNEL_LOG(
+  //         logging_context,
+  //         "unexpected number of dimensions %d in the output shape in node %d",
+  //         shape_tensor.dims->data[0], node_index);
+  //   }
+  //   TF_LITE_ENSURE_STATUS(CheckTensorStaticAllocation(
+  //       logging_context, shape_tensor, shape_tensor_id, node_index));
 
-    const int output_tensor_id = node->outputs->data[0];
-    const TfLiteTensor& output_tensor = tensors[output_tensor_id];
-    TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
-        logging_context, output_tensor, output_tensor_id, node_index));
-    TF_LITE_ENSURE_STATUS(CheckTensorShape(logging_context, output_tensor, 4,
-                                           output_tensor_id));
-    TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
-        logging_context, output_tensor, output_tensor_id, node_index));
+  //   const int output_tensor_id = node->outputs->data[0];
+  //   const TfLiteTensor& output_tensor = tensors[output_tensor_id];
+  //   TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
+  //       logging_context, output_tensor, output_tensor_id, node_index));
+  //   TF_LITE_ENSURE_STATUS(CheckTensorShape(logging_context, output_tensor, 4,
+  //                                          output_tensor_id));
+  //   TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
+  //       logging_context, output_tensor, output_tensor_id, node_index));
 
-    const int32_t* shape_data =
-        reinterpret_cast<const int32_t*>(shape_tensor.data.data);
-    for (int i = 0; i < shape_tensor.dims->data[0]; i++) {
-      const int32_t dim = shape_data[i];
-      if (dim <= 0) {
-        TF_LITE_MAYBE_KERNEL_LOG(
-            logging_context, "invalid output dimension #%d value %d in node %d",
-            i, dim, node_index);
-        return kTfLiteError;
-      }
-    }
+  //   const int32_t* shape_data =
+  //       reinterpret_cast<const int32_t*>(shape_tensor.data.data);
+  //   for (int i = 0; i < shape_tensor.dims->data[0]; i++) {
+  //     const int32_t dim = shape_data[i];
+  //     if (dim <= 0) {
+  //       TF_LITE_MAYBE_KERNEL_LOG(
+  //           logging_context, "invalid output dimension #%d value %d in node %d",
+  //           i, dim, node_index);
+  //       return kTfLiteError;
+  //     }
+  //   }
 
-    if (builder) {
-      wnn::Operand input_operand = webnn_operands[input_tensor_id];
-      TF_LITE_ENSURE(logging_context, input_operand);
-      std::vector<int32_t> sizes = {shape_data[0], shape_data[1]};
-      std::vector<int32_t> axes = {1, 2};
-      wnn::Resample2dOptions options;
-      options.mode = wnn::InterpolationMode::Linear;
-      options.sizes = sizes.data();
-      options.sizesCount = sizes.size();
-      options.axes = axes.data();
-      options.axesCount = axes.size();
-      webnn_operands[output_tensor_id] = builder.Resample2d(input_operand, &options);
-      TF_LITE_ENSURE(logging_context, webnn_operands[output_tensor_id]);
-    }
+  //   if (builder) {
+  //     wnn::Operand input_operand = webnn_operands[input_tensor_id];
+  //     TF_LITE_ENSURE(logging_context, input_operand);
+  //     std::vector<int32_t> sizes = {shape_data[0], shape_data[1]};
+  //     std::vector<int32_t> axes = {1, 2};
+  //     wnn::Resample2dOptions options;
+  //     options.mode = wnn::InterpolationMode::Linear;
+  //     options.sizes = sizes.data();
+  //     options.sizesCount = sizes.size();
+  //     options.axes = axes.data();
+  //     options.axesCount = axes.size();
+  //     webnn_operands[output_tensor_id] = builder.Resample2d(input_operand, &options);
+  //     TF_LITE_ENSURE(logging_context, webnn_operands[output_tensor_id]);
+  //   }
 
-    return kTfLiteOk;
-  }
+  //   return kTfLiteOk;
+  // }
 
   static TfLiteStatus VisitSoftmaxNode(
-      const wnn::GraphBuilder& builder, TfLiteContext* logging_context, int node_index,
+      const emscripten::val& builder, TfLiteContext* logging_context, int node_index,
       TfLiteNode* node, const TfLiteTensor* tensors,
       const TfLiteSoftmaxParams* params,
-      std::vector<wnn::Operand>& webnn_operands) {
+      std::unordered_map<int, emscripten::val>& webnn_operands) {
     if (params->beta != 1.0f) {
       if (logging_context != nullptr) {
         TF_LITE_KERNEL_LOG(logging_context,
@@ -2097,234 +2096,235 @@ class Subgraph {
     TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
         logging_context, output_tensor, output_tensor_id, node_index));
 
-    if (builder) {
-      TF_LITE_ENSURE(logging_context, webnn_operands[input_tensor_id]);
-      webnn_operands[output_tensor_id] = builder.Softmax(webnn_operands[input_tensor_id]);
-      TF_LITE_ENSURE(logging_context, webnn_operands[output_tensor_id]);
+    if (!builder.isNull()) {
+      TF_LITE_ENSURE(logging_context,
+                     webnn_operands.at(input_tensor_id).as<bool>());
+      webnn_operands.insert(
+          std::make_pair(output_tensor_id,
+                         builder.call<emscripten::val>(
+                             "softmax", webnn_operands.at(input_tensor_id))));
+      TF_LITE_ENSURE(logging_context,
+                     webnn_operands.at(output_tensor_id).as<bool>());
     }
 
     return kTfLiteOk;
   }
 
-  static TfLiteStatus VisitSplitNode(
-      const wnn::GraphBuilder& builder, TfLiteContext* logging_context, int node_index,
-      TfLiteNode* node, const TfLiteTensor* tensors,
-      const TfLiteSplitParams* params,
-      std::vector<wnn::Operand>& webnn_operands) {
-    const int num_splits = params->num_splits;
-    if (num_splits == 0) {
-      TF_LITE_MAYBE_KERNEL_LOG(
-          logging_context,
-          "unexpected value of num_splits %d in the split params in node %d",
-          num_splits, node_index);
-      return kTfLiteError;
-    }
+  // static TfLiteStatus VisitSplitNode(
+  //     const wnn::GraphBuilder& builder, TfLiteContext* logging_context, int node_index,
+  //     TfLiteNode* node, const TfLiteTensor* tensors,
+  //     const TfLiteSplitParams* params,
+  //     std::vector<wnn::Operand>& webnn_operands) {
+  //   const int num_splits = params->num_splits;
+  //   if (num_splits == 0) {
+  //     TF_LITE_MAYBE_KERNEL_LOG(
+  //         logging_context,
+  //         "unexpected value of num_splits %d in the split params in node %d",
+  //         num_splits, node_index);
+  //     return kTfLiteError;
+  //   }
 
-    TF_LITE_ENSURE_STATUS(
-        CheckNumInputsAndOutputs(logging_context, node, 2, num_splits, node_index));
+  //   TF_LITE_ENSURE_STATUS(
+  //       CheckNumInputsAndOutputs(logging_context, node, 2, num_splits, node_index));
 
-    const int input_tensor_id = node->inputs->data[1];
-    const TfLiteTensor& input_tensor = tensors[input_tensor_id];
-    TF_LITE_ENSURE_STATUS(CheckTensorFloat32OrQInt8Type(
-        logging_context, input_tensor, input_tensor_id, node_index));
-    TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
-        logging_context, input_tensor, input_tensor_id, node_index));
+  //   const int input_tensor_id = node->inputs->data[1];
+  //   const TfLiteTensor& input_tensor = tensors[input_tensor_id];
+  //   TF_LITE_ENSURE_STATUS(CheckTensorFloat32OrQInt8Type(
+  //       logging_context, input_tensor, input_tensor_id, node_index));
+  //   TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
+  //       logging_context, input_tensor, input_tensor_id, node_index));
 
-    const int axis_tensor_id = node->inputs->data[0];
-    const TfLiteTensor& axis_tensor = tensors[axis_tensor_id];
-    TF_LITE_ENSURE_STATUS(CheckTensorType(logging_context, axis_tensor,
-                                          kTfLiteInt32, axis_tensor_id,
-                                          node_index));
-    TF_LITE_ENSURE_STATUS(CheckTensorShape(logging_context, axis_tensor, 0,
-                                           axis_tensor_id));
-    TF_LITE_ENSURE_STATUS(CheckTensorStaticAllocation(
-        logging_context, axis_tensor, axis_tensor_id, node_index));
+  //   const int axis_tensor_id = node->inputs->data[0];
+  //   const TfLiteTensor& axis_tensor = tensors[axis_tensor_id];
+  //   TF_LITE_ENSURE_STATUS(CheckTensorType(logging_context, axis_tensor,
+  //                                         kTfLiteInt32, axis_tensor_id,
+  //                                         node_index));
+  //   TF_LITE_ENSURE_STATUS(CheckTensorShape(logging_context, axis_tensor, 0,
+  //                                          axis_tensor_id));
+  //   TF_LITE_ENSURE_STATUS(CheckTensorStaticAllocation(
+  //       logging_context, axis_tensor, axis_tensor_id, node_index));
 
-    const int* axis_data =
-        reinterpret_cast<const int*>(axis_tensor.data.data);
-    int axis_value = axis_data[0];
+  //   const int* axis_data =
+  //       reinterpret_cast<const int*>(axis_tensor.data.data);
+  //   int axis_value = axis_data[0];
 
-    const int num_dims = input_tensor.dims->size;
-    if (axis_value < 0) {
-      axis_value += num_dims;
-    }
-    if (axis_value < 0 || axis_value > num_dims) {
-      TF_LITE_MAYBE_KERNEL_LOG(
-          logging_context,
-          "unexpected data of axis %d in the axis tensor in node %d",
-          axis_data[0], node_index);
-      return kTfLiteError;
-    }
-    const int input_size = input_tensor.dims->data[axis_value];
-    if (input_size % num_splits != 0) {
-      TF_LITE_MAYBE_KERNEL_LOG(
-          logging_context,
-          "Not an even split");
-      return kTfLiteError;
-    }
+  //   const int num_dims = input_tensor.dims->size;
+  //   if (axis_value < 0) {
+  //     axis_value += num_dims;
+  //   }
+  //   if (axis_value < 0 || axis_value > num_dims) {
+  //     TF_LITE_MAYBE_KERNEL_LOG(
+  //         logging_context,
+  //         "unexpected data of axis %d in the axis tensor in node %d",
+  //         axis_data[0], node_index);
+  //     return kTfLiteError;
+  //   }
+  //   const int input_size = input_tensor.dims->data[axis_value];
+  //   if (input_size % num_splits != 0) {
+  //     TF_LITE_MAYBE_KERNEL_LOG(
+  //         logging_context,
+  //         "Not an even split");
+  //     return kTfLiteError;
+  //   }
 
-    const int output_size = node->outputs->size;
+  //   const int output_size = node->outputs->size;
 
-    if (builder) {
-      std::vector<uint32_t> splits = {static_cast<const uint32_t>(num_splits)};
-      wnn::SplitOptions options;
-      options.axis = static_cast<const uint32_t>(axis_value);
-      TF_LITE_ENSURE(logging_context, webnn_operands[input_tensor_id]);
-      wnn::OperandArray split_operand_array = builder.Split(
-          webnn_operands[input_tensor_id], splits.data(), splits.size(), &options);
-      TF_LITE_ENSURE(logging_context, split_operand_array.Size() == output_size);
+  //   if (builder) {
+  //     std::vector<uint32_t> splits = {static_cast<const uint32_t>(num_splits)};
+  //     wnn::SplitOptions options;
+  //     options.axis = static_cast<const uint32_t>(axis_value);
+  //     TF_LITE_ENSURE(logging_context, webnn_operands[input_tensor_id]);
+  //     wnn::OperandArray split_operand_array = builder.Split(
+  //         webnn_operands[input_tensor_id], splits.data(), splits.size(), &options);
+  //     TF_LITE_ENSURE(logging_context, split_operand_array.Size() == output_size);
 
-      for (int i = 0; i < output_size; i++) {
-        int output_tensor_id = node->outputs->data[i];
-        const TfLiteTensor& output_tensor = tensors[output_tensor_id];
-        TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
-            logging_context, output_tensor, output_tensor_id, node_index));
-        TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
-            logging_context, output_tensor, output_tensor_id, node_index));
-        webnn_operands[output_tensor_id] = split_operand_array.Get(i);
-        TF_LITE_ENSURE(logging_context, webnn_operands[output_tensor_id]);
-      }
-    }
+  //     for (int i = 0; i < output_size; i++) {
+  //       int output_tensor_id = node->outputs->data[i];
+  //       const TfLiteTensor& output_tensor = tensors[output_tensor_id];
+  //       TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
+  //           logging_context, output_tensor, output_tensor_id, node_index));
+  //       TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
+  //           logging_context, output_tensor, output_tensor_id, node_index));
+  //       webnn_operands[output_tensor_id] = split_operand_array.Get(i);
+  //       TF_LITE_ENSURE(logging_context, webnn_operands[output_tensor_id]);
+  //     }
+  //   }
 
-    return kTfLiteOk;
-  }
+  //   return kTfLiteOk;
+  // }
 
-  static TfLiteStatus VisitTanhNode(
-      const wnn::GraphBuilder& builder, TfLiteContext* logging_context, int node_index,
-      TfLiteNode* node, const TfLiteTensor* tensors,
-      std::vector<wnn::Operand>& webnn_operands) {
-    TF_LITE_ENSURE_STATUS(
-        CheckNumInputsAndOutputs(logging_context, node, 1, 1, node_index));
+  // static TfLiteStatus VisitTanhNode(
+  //     const wnn::GraphBuilder& builder, TfLiteContext* logging_context, int node_index,
+  //     TfLiteNode* node, const TfLiteTensor* tensors,
+  //     std::vector<wnn::Operand>& webnn_operands) {
+  //   TF_LITE_ENSURE_STATUS(
+  //       CheckNumInputsAndOutputs(logging_context, node, 1, 1, node_index));
 
-    const TfLiteTensor& input_tensor = tensors[node->inputs->data[0]];
-    TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
-        logging_context, input_tensor, node->inputs->data[0], node_index));
-    TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
-        logging_context, input_tensor, node->inputs->data[0], node_index));
+  //   const TfLiteTensor& input_tensor = tensors[node->inputs->data[0]];
+  //   TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
+  //       logging_context, input_tensor, node->inputs->data[0], node_index));
+  //   TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
+  //       logging_context, input_tensor, node->inputs->data[0], node_index));
 
-    const TfLiteTensor& output_tensor = tensors[node->outputs->data[0]];
-    TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
-        logging_context, output_tensor, node->outputs->data[0], node_index));
-    TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
-        logging_context, output_tensor, node->outputs->data[0], node_index));
+  //   const TfLiteTensor& output_tensor = tensors[node->outputs->data[0]];
+  //   TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
+  //       logging_context, output_tensor, node->outputs->data[0], node_index));
+  //   TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
+  //       logging_context, output_tensor, node->outputs->data[0], node_index));
 
-    if (builder) {
-      TF_LITE_ENSURE(logging_context, webnn_operands[node->inputs->data[0]]);
-      webnn_operands[node->outputs->data[0]] = builder.Tanh(webnn_operands[node->inputs->data[0]]);
-      TF_LITE_ENSURE(logging_context, webnn_operands[node->outputs->data[0]]);
-    }
+  //   if (builder) {
+  //     TF_LITE_ENSURE(logging_context, webnn_operands[node->inputs->data[0]]);
+  //     webnn_operands[node->outputs->data[0]] = builder.Tanh(webnn_operands[node->inputs->data[0]]);
+  //     TF_LITE_ENSURE(logging_context, webnn_operands[node->outputs->data[0]]);
+  //   }
 
-    return kTfLiteOk;
-  }
+  //   return kTfLiteOk;
+  // }
 
-  static TfLiteStatus VisitUnpackNode(
-      const wnn::GraphBuilder& builder, TfLiteContext* logging_context, int node_index,
-      TfLiteNode* node, const TfLiteTensor* tensors,
-      const TfLiteUnpackParams* params,
-      std::vector<wnn::Operand>& webnn_operands) {
-    const int num = params->num;
-    int axis = params->axis;
+  // static TfLiteStatus VisitUnpackNode(
+  //     const wnn::GraphBuilder& builder, TfLiteContext* logging_context, int node_index,
+  //     TfLiteNode* node, const TfLiteTensor* tensors,
+  //     const TfLiteUnpackParams* params,
+  //     std::vector<wnn::Operand>& webnn_operands) {
+  //   const int num = params->num;
+  //   int axis = params->axis;
 
-    TF_LITE_ENSURE_STATUS(
-        CheckNumInputsAndOutputs(logging_context, node, 1, num, node_index));
+  //   TF_LITE_ENSURE_STATUS(
+  //       CheckNumInputsAndOutputs(logging_context, node, 1, num, node_index));
 
-    const int input_tensor_id = node->inputs->data[0];
-    const TfLiteTensor& input_tensor = tensors[input_tensor_id];
-    TF_LITE_ENSURE_STATUS(CheckTensorFloat32OrQInt8Type(
-        logging_context, input_tensor, input_tensor_id, node_index));
-    TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
-        logging_context, input_tensor, input_tensor_id, node_index));
+  //   const int input_tensor_id = node->inputs->data[0];
+  //   const TfLiteTensor& input_tensor = tensors[input_tensor_id];
+  //   TF_LITE_ENSURE_STATUS(CheckTensorFloat32OrQInt8Type(
+  //       logging_context, input_tensor, input_tensor_id, node_index));
+  //   TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
+  //       logging_context, input_tensor, input_tensor_id, node_index));
 
-    const int num_dims = input_tensor.dims->size;
-    if (axis < 0) {
-      axis += num_dims;
-    }
-    if (axis < 0 || axis >= num_dims) {
-      TF_LITE_MAYBE_KERNEL_LOG(
-          logging_context,
-          "unexpected value of axis %d in the unpack params in node %d",
-          axis, node_index);
-      return kTfLiteError;
-    }
+  //   const int num_dims = input_tensor.dims->size;
+  //   if (axis < 0) {
+  //     axis += num_dims;
+  //   }
+  //   if (axis < 0 || axis >= num_dims) {
+  //     TF_LITE_MAYBE_KERNEL_LOG(
+  //         logging_context,
+  //         "unexpected value of axis %d in the unpack params in node %d",
+  //         axis, node_index);
+  //     return kTfLiteError;
+  //   }
 
-    const int output_size = node->outputs->size;
+  //   const int output_size = node->outputs->size;
 
-    if (num != output_size) {
-      TF_LITE_MAYBE_KERNEL_LOG(
-          logging_context,
-          "unexpected value of num %d in the unpack params in node %d",
-          num, node_index);
-      return kTfLiteError;
-    }
+  //   if (num != output_size) {
+  //     TF_LITE_MAYBE_KERNEL_LOG(
+  //         logging_context,
+  //         "unexpected value of num %d in the unpack params in node %d",
+  //         num, node_index);
+  //     return kTfLiteError;
+  //   }
 
-    if (builder) {
-      TF_LITE_ENSURE(logging_context, webnn_operands[input_tensor_id]);
-      wnn::SqueezeOptions squeeze_options;
-      std::vector<int32_t> axes = {static_cast<int32_t>(axis)};
-      squeeze_options.axes = axes.data();
-      squeeze_options.axesCount = axes.size();
-      // Unpack = split + squeeze in WebNN
-      // No need split if Unpack's num == 1
-      if (num == 1) {
-        int output_tensor_id = node->outputs->data[0];
-        const TfLiteTensor& output_tensor = tensors[output_tensor_id];
-        TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
-            logging_context, output_tensor, output_tensor_id, node_index));
-        TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
-            logging_context, output_tensor, output_tensor_id, node_index));
+  //   if (builder) {
+  //     TF_LITE_ENSURE(logging_context, webnn_operands[input_tensor_id]);
+  //     wnn::SqueezeOptions squeeze_options;
+  //     std::vector<int32_t> axes = {static_cast<int32_t>(axis)};
+  //     squeeze_options.axes = axes.data();
+  //     squeeze_options.axesCount = axes.size();
+  //     // Unpack = split + squeeze in WebNN
+  //     // No need split if Unpack's num == 1
+  //     if (num == 1) {
+  //       int output_tensor_id = node->outputs->data[0];
+  //       const TfLiteTensor& output_tensor = tensors[output_tensor_id];
+  //       TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
+  //           logging_context, output_tensor, output_tensor_id, node_index));
+  //       TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
+  //           logging_context, output_tensor, output_tensor_id, node_index));
 
-        webnn_operands[output_tensor_id] =
-            builder.Squeeze(webnn_operands[input_tensor_id], &squeeze_options);
-        TF_LITE_ENSURE(logging_context, webnn_operands[output_tensor_id]);
-      } else {
-        std::vector<uint32_t> splits = {static_cast<const uint32_t>(num)};
-        wnn::SplitOptions options;
-        options.axis = static_cast<const uint32_t>(axis);
-        wnn::OperandArray split_operand_array = builder.Split(
-            webnn_operands[input_tensor_id], splits.data(), splits.size(), &options);
-        TF_LITE_ENSURE(logging_context, split_operand_array.Size() == output_size);
+  //       webnn_operands[output_tensor_id] =
+  //           builder.Squeeze(webnn_operands[input_tensor_id], &squeeze_options);
+  //       TF_LITE_ENSURE(logging_context, webnn_operands[output_tensor_id]);
+  //     } else {
+  //       std::vector<uint32_t> splits = {static_cast<const uint32_t>(num)};
+  //       wnn::SplitOptions options;
+  //       options.axis = static_cast<const uint32_t>(axis);
+  //       wnn::OperandArray split_operand_array = builder.Split(
+  //           webnn_operands[input_tensor_id], splits.data(), splits.size(), &options);
+  //       TF_LITE_ENSURE(logging_context, split_operand_array.Size() == output_size);
 
-        for (int i = 0; i < output_size; i++) {
-          int output_tensor_id = node->outputs->data[i];
-          const TfLiteTensor& output_tensor = tensors[output_tensor_id];
-          TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
-              logging_context, output_tensor, output_tensor_id, node_index));
-          TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
-              logging_context, output_tensor, output_tensor_id, node_index));
+  //       for (int i = 0; i < output_size; i++) {
+  //         int output_tensor_id = node->outputs->data[i];
+  //         const TfLiteTensor& output_tensor = tensors[output_tensor_id];
+  //         TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
+  //             logging_context, output_tensor, output_tensor_id, node_index));
+  //         TF_LITE_ENSURE_STATUS(CheckTensorNonDynamicAllocation(
+  //             logging_context, output_tensor, output_tensor_id, node_index));
 
-          webnn_operands[output_tensor_id] =
-              builder.Squeeze(split_operand_array.Get(i), &squeeze_options);
-          TF_LITE_ENSURE(logging_context, webnn_operands[output_tensor_id]);
-        }
-      }
-    }
-    return kTfLiteOk;
-  }
+  //         webnn_operands[output_tensor_id] =
+  //             builder.Squeeze(split_operand_array.Get(i), &squeeze_options);
+  //         TF_LITE_ENSURE(logging_context, webnn_operands[output_tensor_id]);
+  //       }
+  //     }
+  //   }
+  //   return kTfLiteOk;
+  // }
 
  private:
-  Subgraph(wnn::Graph graph, std::unordered_set<int>&& inputs, std::unordered_set<int>&& outputs)
+  Subgraph(emscripten::val graph, std::unordered_set<int>&& inputs, std::unordered_set<int>&& outputs)
       : wnn_graph_(graph), inputs_(inputs), outputs_(outputs) {
     for (auto& i : inputs_) {
-      wnn_inputs_[i] = {};
       externals_[i] = nullptr;
     }
     for (auto& o : outputs_) {
-      wnn_outputs_[o] = {};
       externals_[o] = nullptr;
     }
-    graph_inputs_ = wnn::CreateNamedInputs();
-    graph_outputs_ = wnn::CreateNamedOutputs();
+    graph_inputs_ = emscripten::val::object();
+    graph_outputs_ = emscripten::val::object();
   }
 
-  wnn::Graph wnn_graph_;
+  emscripten::val wnn_graph_ = emscripten::val::object();
   // TFLite Tensor IDs == name of input/output tensors for the
   // delegated subgraph.
   std::unordered_set<int> inputs_;
   std::unordered_set<int> outputs_;
-  std::unordered_map<int, wnn::Input> wnn_inputs_;
-  std::unordered_map<int, wnn::Resource> wnn_outputs_;
-  wnn::NamedInputs graph_inputs_;
-  wnn::NamedOutputs graph_outputs_;
+  emscripten::val graph_inputs_ = emscripten::val::object();
+  emscripten::val graph_outputs_ = emscripten::val::object();
   std::unordered_map<int, void*> externals_;
   char dummy_data_{0};
 };
@@ -2424,8 +2424,8 @@ TfLiteIntArray* Delegate::PrepareOpsToDelegate(TfLiteContext* context) {
       }
     }
 
-    wnn::GraphBuilder null_builder;
-    std::vector<wnn::Operand> empty_webnn_operands;
+    emscripten::val null_builder = emscripten::val::null();
+    std::unordered_map<int, emscripten::val> empty_webnn_operands;
     std::vector<std::unique_ptr<char>> empty_buffers;
     if (Subgraph::VisitNode(null_builder, context, registration, node,
                             node_index, quasi_static_tensors,

--- a/tensorflow/lite/delegates/webnn/webnn_delegate.cc
+++ b/tensorflow/lite/delegates/webnn/webnn_delegate.cc
@@ -352,10 +352,7 @@ class Subgraph {
       for (int t : outputs_) {
         std::string name = std::to_string(t);
         auto output_size = context->tensors[t].bytes / 4;
-        auto output_data = context->tensors[t].data.f;
-        emscripten::val view{emscripten::typed_memory_view(output_size, output_data)};
         auto output = emscripten::val::global("Float32Array").new_(output_size);
-        output.call<void>("set", view);
         graph_outputs_.set(name, output);
       }
     }


### PR DESCRIPTION
Emscripten::val allows to transliterate JavaScript API into C++, rewrite webnn delegate with it would help avoid using webnn system libraries, which is limited by Google3.

In this PR I transliterate all the WebNN native APIs and only verified MobileNetV2 and resNet50V2 models.